### PR TITLE
Bala/add reusable actions

### DIFF
--- a/.github/actions/npm_install/action.yml
+++ b/.github/actions/npm_install/action.yml
@@ -14,6 +14,7 @@ runs:
       run: npm ci
       shell: bash
     - name: save_cache
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
         path: node_modules

--- a/.github/actions/npm_install/action.yml
+++ b/.github/actions/npm_install/action.yml
@@ -1,5 +1,5 @@
-name: npm_install_from_cache
-description: Install npm packages from cache
+name: npm_install
+description: Install npm packages
 runs:
   using: composite
   steps:
@@ -7,7 +7,7 @@ runs:
       id: cache-node-modules
       uses: actions/cache/restore@v3
       with:
-        key: v1-deps-{{ checksum "package-lock.json" }}
+        key: v1-deps-{{ hashFiles("package-lock.json") }}
         path: node_modules
     - name: Install npm dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -17,4 +17,4 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: node_modules
-        key: v1-deps-{{ checksum "package-lock.json" }}
+        key: v1-deps-{{ hashFiles("package-lock.json") }}

--- a/.github/actions/npm_install_from_cache/action.yml
+++ b/.github/actions/npm_install_from_cache/action.yml
@@ -1,0 +1,20 @@
+name: npm_install_from_cache
+description: Install npm packages from cache
+runs:
+  using: composite
+  steps:
+    - name: Cache dependencies
+      id: cache-node-modules
+      uses: actions/cache/restore@v3
+      with:
+        key: v1-deps-{{ checksum "package-lock.json" }}
+        path: node_modules
+    - name: Install npm dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci
+      shell: bash
+    - name: save_cache
+      uses: actions/cache/save@v3
+      with:
+        path: node_modules
+        key: v1-deps-{{ checksum "package-lock.json" }}

--- a/.github/actions/post_preview_build_comment/action.yml
+++ b/.github/actions/post_preview_build_comment/action.yml
@@ -1,0 +1,55 @@
+name: post_action_build_comment
+description: post action build comment
+inputs:
+  issue_number:
+    description: "PR number"
+    required: true
+outputs:
+  check_run_id:
+    description: "Id of the created check"
+    value: ${{ steps.create_build_check.outputs.check_run_id }}
+runs:
+  using: composite
+  steps:
+    - name: "Create action link comment"
+      id: create_build_comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const action_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          const comment = [
+              '| Name | Result |',
+              '| :--- | :------ |',
+              `| **Build status**  | Building 🔨 |`,
+              `| **Action URL**  | [Visit Action](${action_url}) |`,
+              ''
+            ].join('\n')
+          core.setOutput("comment", comment);
+    - name: Post Cloudflare Pages Preview comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Cloudflare Pages Preview Comment
+        number: ${{ inputs.issue_number }}
+        message: ${{steps.create_build_comment.outputs.comment}}
+        recreate: true
+
+    - name: "Create a build check"
+      id: create_build_check
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const action_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          const check = await github.rest.checks.create({
+              ...context.repo,
+              name: "Generate preview link",
+              head_sha: github.event.workflow_run.head_sha,
+              details_url: action_url,
+              status: "in_progress",
+              output: {
+                title: "Generate preview link",
+                summary: "Preview link creation is in progress",
+              },
+          });
+          core.setOutput("check_run_id", check.data.id);

--- a/.github/actions/post_preview_build_comment/action.yml
+++ b/.github/actions/post_preview_build_comment/action.yml
@@ -1,8 +1,11 @@
-name: post_action_build_comment
-description: post action build comment
+name: post_preview_build_comment
+description: Post preview build comment
 inputs:
   issue_number:
     description: "PR number"
+    required: true
+  head_sha:
+    description: "SHA of the commit"
     required: true
 outputs:
   check_run_id:
@@ -11,8 +14,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: "Create action link comment"
-      id: create_build_comment
+    - name: "Post build comment"
+      id: post_build_comment
       uses: actions/github-script@v3
       with:
         github-token: ${{ github.token }}
@@ -26,12 +29,12 @@ runs:
               ''
             ].join('\n')
           core.setOutput("comment", comment);
-    - name: Post Cloudflare Pages Preview comment
+    - name: "Post Cloudflare Pages Preview comment"
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: Cloudflare Pages Preview Comment
         number: ${{ inputs.issue_number }}
-        message: ${{steps.create_build_comment.outputs.comment}}
+        message: ${{steps.post_build_comment.outputs.comment}}
         recreate: true
 
     - name: "Create a build check"
@@ -44,12 +47,12 @@ runs:
           const check = await github.rest.checks.create({
               ...context.repo,
               name: "Generate preview link",
-              head_sha: github.event.workflow_run.head_sha,
+              head_sha: "${{ inputs.head_sha }}",
               details_url: action_url,
               status: "in_progress",
               output: {
                 title: "Generate preview link",
-                summary: "Preview link creation is in progress",
+                summary: `Preview link creation is in progress. Build URL: - ${action_url}`,
               },
           });
           core.setOutput("check_run_id", check.data.id);

--- a/.github/actions/post_preview_link_comment/action.yml
+++ b/.github/actions/post_preview_link_comment/action.yml
@@ -1,0 +1,80 @@
+name: post_preview_link_comment
+description: Post preview link comment
+inputs:
+  issue_number:
+    description: "PR number"
+    required: true
+  preview_url:
+    description: "URL of the published deployment"
+    required: true
+  check_run_id:
+    description: "Id of the created check"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Create preview link comment"
+      if: success()
+      id: create_preview_comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const action_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          const preview_url = "${{ inputs.preview_url }}"
+          const comment = [
+              `**Preview Link**: ${preview_url}`,
+              '| Name | Result |',
+              '| :--- | :------ |',
+              `| **Build status**  | Completed ✅ |`,
+              `| **Preview URL**  | [Visit Preview](${preview_url}) |`,
+              `| **Action URL**  | [Visit Action](${action_url}) |`,
+              ''
+            ].join('\n')
+          core.setOutput("comment", comment);
+    - name: "Create failure comment"
+      if: failure()
+      id: create_failure_comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const action_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          const comment = [
+            '| Name | Result |',
+            '| :--- | :------ |',
+            `| **Build status**  | Failed ❌ |`,
+            `| **Action URL**  | [Visit Action](${action_url}) |`,
+            ''
+          ].join('\n')
+          core.setOutput("comment", comment);
+    - name: Post Cloudflare Pages Preview comment
+      if: success() || failure()
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Cloudflare Pages Preview Comment
+        number: ${{ inputs.issue_number }}
+        message: ${{steps.create_preview_comment.outputs.comment || steps.create_failure_comment.outputs.comment }}
+        recreate: true
+
+    - name: "Update the build check"
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const conclusion = ${{success()}} ? 'success' : ${{cancelled()}} ? 'cancelled' : 'failure';
+          const details_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          await github.rest.checks.update({
+            ...context.repo,
+            name: "Generate preview link",
+            check_run_id: "${{ inputs.check_run_id }}"
+            head_sha: github.event.workflow_run.head_sha,
+            details_url,
+            status: "completed",
+            conclusion,
+            output: {
+              title: "Generate preview link",
+              summary: "Generate preview link build check",
+            },
+          });

--- a/.github/actions/post_preview_link_comment/action.yml
+++ b/.github/actions/post_preview_link_comment/action.yml
@@ -10,13 +10,15 @@ inputs:
   check_run_id:
     description: "Id of the created check"
     required: true
-
+  status:
+    description: "Status of the job"
+    required: true
 runs:
   using: composite
   steps:
-    - name: "Create preview link comment"
-      if: success()
-      id: create_preview_comment
+    - name: "Post preview link comment"
+      if: ${{ inputs.status == 'success' }}
+      id: post_preview_comment
       uses: actions/github-script@v3
       with:
         github-token: ${{ github.token }}
@@ -33,9 +35,9 @@ runs:
               ''
             ].join('\n')
           core.setOutput("comment", comment);
-    - name: "Create failure comment"
-      if: failure()
-      id: create_failure_comment
+    - name: "Post failure comment"
+      if: ${{ inputs.status == 'failure' }}
+      id: post_failure_comment
       uses: actions/github-script@v3
       with:
         github-token: ${{ github.token }}
@@ -50,31 +52,31 @@ runs:
           ].join('\n')
           core.setOutput("comment", comment);
     - name: Post Cloudflare Pages Preview comment
-      if: success() || failure()
+      if: ${{ inputs.status == 'success' || inputs.status == 'failure' }}
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: Cloudflare Pages Preview Comment
         number: ${{ inputs.issue_number }}
-        message: ${{steps.create_preview_comment.outputs.comment || steps.create_failure_comment.outputs.comment }}
+        message: ${{steps.post_preview_comment.outputs.comment || steps.post_failure_comment.outputs.comment }}
         recreate: true
 
     - name: "Update the build check"
       uses: actions/github-script@v7
+      if: always()
       with:
         github-token: ${{ github.token }}
         script: |
-          const conclusion = ${{success()}} ? 'success' : ${{cancelled()}} ? 'cancelled' : 'failure';
-          const details_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          const conclusion = "${{ inputs.status }}"
+          const action_url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           await github.rest.checks.update({
             ...context.repo,
             name: "Generate preview link",
-            check_run_id: "${{ inputs.check_run_id }}"
-            head_sha: github.event.workflow_run.head_sha,
-            details_url,
+            check_run_id: "${{ inputs.check_run_id }}",
+            details_url: action_url,
             status: "completed",
             conclusion,
             output: {
               title: "Generate preview link",
-              summary: "Generate preview link build check",
+              summary: `Preview link creation status: ${conclusion}. Build URL: - ${action_url}`,
             },
           });

--- a/.github/actions/publish_to_pages_branch/action.yml
+++ b/.github/actions/publish_to_pages_branch/action.yml
@@ -1,0 +1,42 @@
+name: publish_to_pages_branch
+description: Publish to cloudflare pages (branch)
+inputs:
+  CLOUDFLARE_ACCOUNT_ID:
+    description: "Cloudflare account id"
+    required: true
+  CLOUDFLARE_API_TOKEN:
+    description: "Cloudflare token"
+    required: true
+  project_name:
+    description: "Name of the project in Cloudflare Pages"
+    required: true
+  branch_name:
+    description: "Name of the branch in Cloudflare Pages (e.g., staging, uat, etc.)"
+    required: true
+  output_dir:
+    description: "Directory in which your compiled frontend is located"
+    required: true
+  cname_url:
+    description: "URL of the latest deployed website. (e.g., https://staging-app.deriv.com)"
+    required: false
+    default: "N/A"
+outputs:
+  cf_pages_url:
+    description: "URL of the published deployment"
+    value: ${{ steps.publish-to-clouflare-pages-branch.outputs.cf_pages_url }}
+runs:
+  using: composite
+  steps:
+    - id: publish-to-clouflare-pages-branch
+      name: Publish to cloudflare pages (branch)
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+      run: |
+        npm i -g wrangler@3.1.0
+        branch=$(echo ${{ inputs.branch_name }} | sed 's/[^a-zA-Z0-9]/-/g' | head -c 20)
+        npx wrangler pages deploy ${{ inputs.output_dir }} --project-name=${{ inputs.project_name }} --branch=$branch
+        cf_pages_url=https://$branch.${{ inputs.project_name }}.pages.dev
+        echo "cf_pages_url=$cf_pages_url" >> "$GITHUB_OUTPUT"
+        echo "New branch website - ${{ inputs.cname_url }}"
+      shell: bash

--- a/.github/actions/publish_to_pages_production/action.yml
+++ b/.github/actions/publish_to_pages_production/action.yml
@@ -1,0 +1,31 @@
+name: publish_to_pages_production
+description: Publish to cloudflare pages (production)
+inputs:
+  CLOUDFLARE_ACCOUNT_ID:
+    description: "Cloudflare account id"
+    required: true
+  CLOUDFLARE_API_TOKEN:
+    description: "Cloudflare token"
+    required: true
+  project_name:
+    description: "Name of the project in Cloudflare Pages"
+    required: true
+  output_dir:
+    description: "Directory in which your compiled frontend is located"
+    required: true
+  cname_url:
+    description: "URL of the latest deployed website. (e.g., https://app.deriv.com)"
+    required: false
+    default: "N/A"
+runs:
+  using: composite
+  steps:
+    - name: Publish to cloudflare pages (production)
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+      run: |
+        npm i -g wrangler@3.1.0
+        npx wrangler pages deploy ${{ inputs.output_dir }} --project-name=${{ inputs.project_name }} --branch=main
+        echo "New production website - ${{ inputs.cname_url }}"
+      shell: bash

--- a/.github/actions/verify_user_in_organization/action.yml
+++ b/.github/actions/verify_user_in_organization/action.yml
@@ -1,0 +1,29 @@
+name: verify_user_in_organization
+description: Verify user in organization
+inputs:
+  username:
+    description: "The id of the user"
+    required: true
+  token:
+    description: "Token to access Github API"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Verify user in organization
+      id: verify_user_in_organization
+      run: |
+        echo "Verifying user's organization..."
+        response=$(curl -s -L \
+            -w "%{http_code}" \
+            -o /dev/null -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ inputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/${{vars.ORGANIZATION_VAR}}/memberships/${{inputs.username}}")
+            
+        if [ $response != "200" ]; then
+            echo "User is not a member of ${{vars.ORGANIZATION_VAR}} organization."
+            exit 1
+        else
+            echo "User is a member of ${{vars.ORGANIZATION_VAR}} organization."
+        fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Shared Actions Repository
 
-This repository is dedicated to hosting reusable GitHub Actions YAML files that can be shared across different repositories. By centralizing common actions, you can promote consistency and efficiency in your workflows.
+This repository is dedicated to hosting reusable GitHub Actions YAML files that can be shared across different repositories. Centralizing common actions, to promote consistency and efficiency in workflows.
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# shared-actions
+## Shared Actions Repository
+
+This repository is dedicated to hosting reusable GitHub Actions YAML files that can be shared across different repositories. By centralizing common actions, you can promote consistency and efficiency in your workflows.
+
+#### Example Usage
+
+```
+      - name: Post preview build comment
+        id: post_preview_build_comment
+        uses: "deriv-com/shared-actions/.github/actions/post_preview_build_comment@v1"
+        with:
+          issue_number: ${{steps.pr_information.outputs.issue_number}}
+          head_sha: ${{github.event.workflow_run.head_sha}}
+```


### PR DESCRIPTION
Add reusable actions such as npm install, post build comment, post preview URL, publish to pages, and verify user in an organization. These actions are created in this repo for easy maintenance and they will be reused in workflows in multiple repos.