### PR TITLE
chore: add deployment txt file

### DIFF
--- a/.github/actions/vercel_DR_publish/action.yml
+++ b/.github/actions/vercel_DR_publish/action.yml
@@ -48,6 +48,10 @@ runs:
       run: |
         vercel pull --yes --token=$VERCEL_TOKEN --scope=$VERCEL_SCOPE
 
+    - name: Create deployment.txt file
+      run: echo "This is being published from Vercel" > deployment.txt
+      shell: bash
+
     - name: Deploy to Vercel (Staging)
       env:
         VERCEL_TOKEN: ${{ inputs.VERCEL_TOKEN }}


### PR DESCRIPTION
This PR creates a deployment.txt file in the publish and writes the text "this is from vercel" to it. So that when user navigates to the site/deployment.txt, the file content would be displayed.