### PR TITLE
Adrienne / Update Github Actions cache to V4

### DIFF
--- a/.github/actions/npm_install/action.yml
+++ b/.github/actions/npm_install/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Cache dependencies
       id: cache-node-modules
-      uses: actions/cache/restore@e12d46a63a90f2fae62d114769bbf2a179198b5c
+      uses: actions/cache/restore@v4
       with:
         key: v1-deps-{{ hashFiles("package-lock.json") }}
         path: node_modules
@@ -15,7 +15,7 @@ runs:
       shell: bash
     - name: save_cache
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      uses: actions/cache/save@e12d46a63a90f2fae62d114769bbf2a179198b5c
+      uses: actions/cache/save@v4
       with:
         path: node_modules
         key: v1-deps-{{ hashFiles("package-lock.json") }}


### PR DESCRIPTION
Github Actions V3 is deprecated and causing workflows to fail, updated it to V4
<img width="1291" alt="Screenshot 2025-03-12 at 1 32 24 PM" src="https://github.com/user-attachments/assets/8488dff5-a14c-4ced-9f83-58349d409d06" />
