### PR TITLE
ci: add Click2fix (Claude PR Review) reusable workflow(s)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,19 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  claude-review:
+    uses: deriv-com/shared-actions/.github/workflows/claude-pr-review.yml@master
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AGENT_METRICS_API_URL: ${{ secrets.AGENT_METRICS_API_URL }}
+      AGENT_METRICS_API_KEY: ${{ secrets.AGENT_METRICS_API_KEY }}


### PR DESCRIPTION
Adds the following reusable workflow(s) in this repository:

**Added:**
- `.github/workflows/claude.yml`

This PR was created via the [OneAboveAll](/) dashboard by @ilfa-deriv.

### Required secrets
Before merging, ensure the following repository/org secrets are configured:
- `ANTHROPIC_API_KEY` _(if applicable)_
- `AGENT_METRICS_API_URL`
- `AGENT_METRICS_API_KEY`