### PR TITLE
Route Claude PR review through company-wide LiteLLM gateway

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -267,10 +267,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           # Route Claude Code through the company-wide LiteLLM gateway (Anthropic-compatible).
-          # TODO: confirm the base URL path with #need_help_infra_prod — LiteLLM serves the
-          # Anthropic wire format on /anthropic, while /v1 is the OpenAI-compatible route.
           ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
-          # LiteLLM authenticates with a bearer token, not an Anthropic x-api-key.
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       claude_model:
-        description: "Claude model to use for review"
+        description: "Claude model to use for review (must be a model your LiteLLM service account exposes)"
         required: false
         default: "claude-opus-4-8"
         type: string
@@ -15,7 +15,7 @@ on:
         type: string
     secrets:
       ANTHROPIC_API_KEY:
-        description: "Anthropic API key for Claude"
+        description: "LiteLLM service-account key (sk-...) for the company-wide gateway"
         required: true
       AGENT_METRICS_API_URL:
         description: "Base URL for the OneAboveAll metrics dashboard API (e.g. https://dashboard.example.com). Leave unset to skip POSTing events."
@@ -265,8 +265,14 @@ jobs:
 
       - name: Claude Code PR Review
         uses: anthropics/claude-code-action@v1
+        env:
+          # Route Claude Code through the company-wide LiteLLM gateway (Anthropic-compatible).
+          # TODO: confirm the base URL path with #need_help_infra_prod — LiteLLM serves the
+          # Anthropic wire format on /anthropic, while /v1 is the OpenAI-compatible route.
+          ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
+          # LiteLLM authenticates with a bearer token, not an Anthropic x-api-key.
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## What

Migrates the `claude-pr-review.yml` reusable workflow off the direct Anthropic API and onto the company-wide **LiteLLM** service account.

## Why

The standalone Anthropic key is being retired in favor of the shared LiteLLM gateway (`litellmsa.deriv.ai`), which is the org-wide managed service. This workflow is shared across repos, so it needs to route through LiteLLM to keep PR reviews working.

## Changes

- The `Claude Code PR Review` step now sets `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (bearer auth) in its `env` block, instead of passing `anthropic_api_key`. Claude Code (the CLI the action runs) reads these env vars and routes its API calls to the gateway.
- The existing `ANTHROPIC_API_KEY` secret is **reused** to carry the LiteLLM `sk-...` key — so **caller repos do not need to rename anything**, only update the secret's value.
- Updated the secret + `claude_model` input descriptions to reflect the LiteLLM source.

## Action required before merge / after merge

- [ ] **Set the `ANTHROPIC_API_KEY` secret** to the LiteLLM service-account key (`sk-...`) in this repo and any caller repos.
- [ ] **Confirm the base URL path** with `#need_help_infra_prod`. This PR uses `https://litellmsa.deriv.ai/v1` (the OpenAI-compatible route shown in the service-account UI). Claude Code speaks the **Anthropic** wire format, which LiteLLM typically serves on `/anthropic` — if reviews 404 on connection, switch the URL to `https://litellmsa.deriv.ai/anthropic`. (Flagged with a TODO comment in the file.)
- [ ] **Verify the model.** The service account exposes `claude-sonnet-4-6`; the workflow still defaults to `claude-opus-4-8`. If callers don't override `claude_model`, the default may need to change to a model the account exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)