### PR TITLE
fix: pass LiteLLM key as ANTHROPIC_API_KEY (validation was failing)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -267,8 +267,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           # Route Claude Code through the company-wide LiteLLM gateway (Anthropic-compatible).
+          # The action validates that ANTHROPIC_API_KEY is set before it starts Claude Code,
+          # so the LiteLLM key must be passed as ANTHROPIC_API_KEY (sent as the x-api-key header,
+          # which LiteLLM accepts) — not ANTHROPIC_AUTH_TOKEN, which the validator ignores.
           ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Problem

After #90 merged, every repo using `claude-pr-review.yml@master` fails at the action's pre-flight check:

```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity
    federation (...) is required when using direct Anthropic API.
```

## Cause

#90 was merged with the env var named `ANTHROPIC_AUTH_TOKEN`. The follow-up fix commit that renamed it was pushed *after* the merge, so it never landed — `master` still has the broken name.

The action's `validate-env` step only accepts `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or workload-identity vars. `ANTHROPIC_AUTH_TOKEN` is not checked, so the secret is effectively invisible to the validator and the job fails before Claude Code starts.

## Fix

Pass the LiteLLM key as `ANTHROPIC_API_KEY` in the step `env`. This satisfies the validator, and Claude Code sends it as the `x-api-key` header — which LiteLLM accepts. Combined with `ANTHROPIC_BASE_URL`, requests route to the gateway.

```diff
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

No caller-side change needed — callers already pass `ANTHROPIC_API_KEY` and pin `@master`.

## Still to confirm after this merges

If reviews now fail at **runtime** (404 / model error) rather than validation, switch the base URL from `https://litellmsa.deriv.ai/v1` (OpenAI route) to `https://litellmsa.deriv.ai/anthropic` (Anthropic route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)