### PR TITLE
fix: pass LiteLLM key via anthropic_api_key input + base URL at job level

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,6 +42,10 @@ jobs:
 
     env:
       CLAUDE_MODEL: ${{ inputs.claude_model || 'claude-opus-4-8' }}
+      # Route Claude Code through the company-wide LiteLLM gateway. Must be job-level:
+      # the action forwards ANTHROPIC_BASE_URL to the Claude CLI via ${{ env.ANTHROPIC_BASE_URL }},
+      # and its inner step env: shadows the calling step's env:, so a step-level value is dropped.
+      ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
 
     steps:
       - name: Security Check - Validate User Access
@@ -265,14 +269,13 @@ jobs:
 
       - name: Claude Code PR Review
         uses: anthropics/claude-code-action@v1
-        env:
-          # Route Claude Code through the company-wide LiteLLM gateway (Anthropic-compatible).
-          # The action validates that ANTHROPIC_API_KEY is set before it starts Claude Code,
-          # so the LiteLLM key must be passed as ANTHROPIC_API_KEY (sent as the x-api-key header,
-          # which LiteLLM accepts) — not ANTHROPIC_AUTH_TOKEN, which the validator ignores.
-          ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
+          # LiteLLM service-account key (sk-...). Must go through the action's
+          # anthropic_api_key INPUT — its inner steps set ANTHROPIC_API_KEY from
+          # inputs.anthropic_api_key and shadow the calling step's env:, so a
+          # step-level ANTHROPIC_API_KEY arrives empty and fails validation.
+          # ANTHROPIC_BASE_URL is set at job level (read via env.) above.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,9 +42,6 @@ jobs:
 
     env:
       CLAUDE_MODEL: ${{ inputs.claude_model || 'claude-opus-4-8' }}
-      # Route Claude Code through the company-wide LiteLLM gateway. Must be job-level:
-      # the action forwards ANTHROPIC_BASE_URL to the Claude CLI via ${{ env.ANTHROPIC_BASE_URL }},
-      # and its inner step env: shadows the calling step's env:, so a step-level value is dropped.
       ANTHROPIC_BASE_URL: "https://litellmsa.deriv.ai/v1"
 
     steps:
@@ -270,11 +267,6 @@ jobs:
       - name: Claude Code PR Review
         uses: anthropics/claude-code-action@v1
         with:
-          # LiteLLM service-account key (sk-...). Must go through the action's
-          # anthropic_api_key INPUT — its inner steps set ANTHROPIC_API_KEY from
-          # inputs.anthropic_api_key and shadow the calling step's env:, so a
-          # step-level ANTHROPIC_API_KEY arrives empty and fails validation.
-          # ANTHROPIC_BASE_URL is set at job level (read via env.) above.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Problem

Even after #91, callers still fail validation:

```
Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation ...
```

The run log shows why: the **outer** action step receives `ANTHROPIC_API_KEY: ***` (set), but the **inner** base-action step logs `ANTHROPIC_API_KEY:` (empty) and `"anthropic_api_key": ""`.

## Cause

`claude-code-action`'s composite steps **shadow the calling step's `env:`** (there's an explicit comment about this in its `action.yml`) and re-derive their environment:

- `ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}` (action.yml:314, :418) — the inner validator reads the key from the **input**, not from an inherited env var. We had removed it from `with:`, so it was empty.
- `ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}` (action.yml:321) — forwarded from **job-level** env, not the step's `env:`.

So both of our placements were being dropped.

## Fix

- Pass the LiteLLM `sk-...` key through the **`anthropic_api_key` input** (`with:`) so it reaches `inputs.anthropic_api_key` → the inner `validate-env` and the Claude CLI.
- Move **`ANTHROPIC_BASE_URL` to job-level `env:`** so the action forwards it to the CLI subprocess and requests actually route to LiteLLM.

No caller-side change needed.

## Still to confirm after merge

If validation now passes but requests fail at runtime (404 / model error), switch the base URL from `…/v1` (OpenAI route) to `…/anthropic` (Anthropic route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)