### PR TITLE
ci: run Claude PR review on self-hosted runner (Cloudflare reachability)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,7 +26,10 @@ on:
 
 jobs:
   claude-review-api:
-    runs-on: ubuntu-latest
+    # Self-hosted runner inside Deriv's network — required so requests reach the
+    # LiteLLM gateway (litellmsa.deriv.ai), which Cloudflare blocks from
+    # GitHub-hosted runner IPs.
+    runs-on: github-hosted-code-reviewer
     if: github.event.pull_request.draft == false
 
     permissions:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,10 +26,11 @@ on:
 
 jobs:
   claude-review-api:
-    # Self-hosted runner inside Deriv's network — required so requests reach the
-    # LiteLLM gateway (litellmsa.deriv.ai), which Cloudflare blocks from
+    # Self-hosted runner group inside Deriv's network — required so requests reach
+    # the LiteLLM gateway (litellmsa.deriv.ai), which Cloudflare blocks from
     # GitHub-hosted runner IPs.
-    runs-on: github-hosted-code-reviewer
+    runs-on:
+      group: github-hosted-code-reviewer
     if: github.event.pull_request.draft == false
 
     permissions:


### PR DESCRIPTION
## Problem

With auth/validation now working, the review fails at the API call:

```
Failed to authenticate. API Error: Attention Required! | Cloudflare
```

That block page comes from **Cloudflare in front of `litellmsa.deriv.ai`**, not from LiteLLM — the request never reaches the gateway. Cloudflare rejects traffic from GitHub-hosted runner IPs (Azure), which aren't on the gateway's allowlist.

## Fix

Run the job on the in-network self-hosted runner instead of `ubuntu-latest`:

```diff
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-code-reviewer
```

The self-hosted runner sits inside Deriv's network, on the allowlisted side of Cloudflare, so requests to `litellmsa.deriv.ai` get through.

## Notes

- Requires the `github-hosted-code-reviewer` self-hosted runner to be available to caller repos (org-level runner group with access to those repos), since this is a reusable workflow.
- Base URL is still `…/v1`. If, once Cloudflare is cleared, requests fail with a 404 / path error, switch to `…/anthropic` (the Anthropic-format route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)