### PR TITLE
ci: switch PR reviewer to github_claude_code_reviewer runner group

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,7 +26,8 @@ on:
 
 jobs:
   claude-review-api:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: github_claude_code_reviewer
     if: github.event.pull_request.draft == false
 
     permissions:


### PR DESCRIPTION
## Summary
Updates the Claude PR review workflow to run on the `github_claude_code_reviewer` self-hosted runner group instead of `ubuntu-latest`.

The self-hosted runner group inside Deriv's network is required so requests reach the LiteLLM gateway (litellmsa.deriv.ai), which Cloudflare blocks from GitHub-hosted runner IPs.

## Changes
- `.github/workflows/claude-pr-review.yml`: `runs-on: ubuntu-latest` → `runs-on.group: github_claude_code_reviewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)