### PR TITLE
ci: enable show_full_output on PR review to expose gateway errors

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -270,6 +270,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Temporary: surface the full SDK output so a failed gateway request
+          # shows its actual error (status code / body) instead of just is_error.
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem
On `deriv-com/derivatives-trader` PR #810, the Claude PR Review workflow failed at the **Post review** step with `❌ Review file missing or empty`. That message is a red herring — the real failure is upstream in the **Claude Code PR Review** step:

```
"type": "result", "subtype": "success", "is_error": true,
"duration_ms": 566, "num_turns": 1, "total_cost_usd": 0
```

Claude exited after ~566ms / 1 turn / \$0 cost with `is_error: true` — i.e. the **first request to the LiteLLM gateway was rejected before any tokens were generated**, so Claude never wrote `/tmp/claude_review_output.txt`.

The actual error (status code + response body) is hidden because `show_full_output` defaults to `false`.

## Change
Set `show_full_output: true` on the `anthropics/claude-code-action@v1` step so the next run prints the real gateway error (401 / 404 / model-not-exposed / network). This is a temporary diagnostic toggle — once the root cause is fixed we can revert it.

## Next steps after merge
Re-run the review on a PR and read the now-visible error to determine whether the gateway rejection is auth, model exposure, or path related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)