### PR TITLE
ci: set ANTHROPIC_API_KEY env to pass action env validation

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -268,15 +268,15 @@ jobs:
         timeout-minutes: 60
         env:
           ANTHROPIC_BASE_URL: https://litellmsa.deriv.ai
-          # ANTHROPIC_API_KEY is required by the action's own env validation
-          # (validate-env.ts checks process.env.ANTHROPIC_API_KEY); ANTHROPIC_AUTH_TOKEN
-          # is what the Claude CLI sends to the gateway. Set both to the same secret.
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # ANTHROPIC_AUTH_TOKEN is the bearer the Claude CLI sends to the gateway.
+          # The api key for the action's env validation is passed via the
+          # anthropic_api_key `with:` input below (maps to ANTHROPIC_API_KEY).
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1"
         with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           show_full_output: true

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -268,6 +268,10 @@ jobs:
         timeout-minutes: 60
         env:
           ANTHROPIC_BASE_URL: https://litellmsa.deriv.ai
+          # ANTHROPIC_API_KEY is required by the action's own env validation
+          # (validate-env.ts checks process.env.ANTHROPIC_API_KEY); ANTHROPIC_AUTH_TOKEN
+          # is what the Claude CLI sends to the gateway. Set both to the same secret.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -268,9 +268,6 @@ jobs:
         timeout-minutes: 60
         env:
           ANTHROPIC_BASE_URL: https://litellmsa.deriv.ai
-          # ANTHROPIC_AUTH_TOKEN is the bearer the Claude CLI sends to the gateway.
-          # The api key for the action's env validation is passed via the
-          # anthropic_api_key `with:` input below (maps to ANTHROPIC_API_KEY).
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"


### PR DESCRIPTION
## Problem

After the last change, the Claude Code PR Review step fails before running with:

```
Action failed with error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

(seen in deriv-com/derivatives-smarttrader#214, run 27597324848)

## Root cause

The action's `base-action/src/validate-env.ts` runs a pre-flight check that reads `process.env.ANTHROPIC_API_KEY` (or `CLAUDE_CODE_OAUTH_TOKEN`). We were only setting `ANTHROPIC_AUTH_TOKEN`, which the validator never inspects — so it aborted before the Claude CLI ever started.

`ANTHROPIC_AUTH_TOKEN` is the bearer token the CLI sends to the gateway; it does **not** satisfy the action's input validation.

## Fix

Set `ANTHROPIC_API_KEY` alongside `ANTHROPIC_AUTH_TOKEN` (both from the same `secrets.ANTHROPIC_API_KEY`). This satisfies the validator while `ANTHROPIC_BASE_URL` continues to route traffic through `litellmsa.deriv.ai`.

## Testing

- YAML parses cleanly.
- Validation logic confirmed against the pinned action SHA `fefa07e` (`validate-env.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)