### PR TITLE
ci: move claude_args next to other with: inputs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -268,15 +268,15 @@ jobs:
         timeout-minutes: 60
         env:
           ANTHROPIC_BASE_URL: https://litellmsa.deriv.ai
-          # ANTHROPIC_AUTH_TOKEN is the bearer the Claude CLI sends to the gateway.
-          # The api key for the action's env validation is passed via the
-          # anthropic_api_key `with:` input below (maps to ANTHROPIC_API_KEY).
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model ${{ env.CLAUDE_MODEL }}
+            --allowedTools "Read,Write,Bash(gh pr diff:*),Bash(gh pr view:*)"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           show_full_output: true
@@ -302,12 +302,6 @@ jobs:
             5. After reading ALL files and dependencies, compile your complete review.
                Write the ENTIRE review to /tmp/claude_review_output.txt using the Write tool.
                Do NOT call gh pr comment — the next step posts the file as a single comment.
-          # Write is unrestricted (plain "Write", not "Write(/path)") so the tool is actually available.
-          # Bash(gh pr comment) is intentionally excluded — the post step below guarantees exactly one comment.
-          # model moved to claude_args — `model` is no longer a valid action input.
-          claude_args: |
-            --model ${{ env.CLAUDE_MODEL }}
-            --allowedTools "Read,Write,Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Post review as single PR comment
         env:


### PR DESCRIPTION
## What

Relocate the `claude_args` block in the Claude Code PR Review step so it sits alongside the other `with:` inputs (`anthropic_api_key`, `github_token`, `track_progress`, …) instead of trailing after the multi-line `prompt:`. Also drops a few now-stale inline comments.

## Why

Readability — `claude_args` is an action input like the others and reads more clearly grouped with them rather than buried after the prompt heredoc.

## Behavioral impact

None.
- Model still resolves from `${{ env.CLAUDE_MODEL }}` (job-level env, defaulting to `claude-sonnet-4-6`).
- `--allowedTools` set is unchanged.
- All `$CLAUDE_MODEL` references in the build-context and metrics steps still resolve.

## Testing

- YAML parses cleanly.
- Confirmed `claude_args` resolves to the same single value and `CLAUDE_MODEL` job env is intact.

> Note: this is a cosmetic follow-up. The Cloudflare 403 seen on `litellmsa.deriv.ai` from GitHub-hosted runners is an infrastructure/allowlisting issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)