### PR TITLE
ci: run PR review on self-hosted runner group

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,7 +26,8 @@ on:
 
 jobs:
   claude-review-api:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: github_claude_code_reviewer
     if: github.event.pull_request.draft == false
 
     permissions:


### PR DESCRIPTION
## What

Switch the `claude-review-api` job from GitHub-hosted `ubuntu-latest` to the self-hosted runner group `github_claude_code_reviewer`:

```yaml
runs-on:
  group: github_claude_code_reviewer
```

## Why

The previous run failed with a **Cloudflare 403** ("Sorry, you have been blocked — you are unable to access deriv.ai") when the action called `https://litellmsa.deriv.ai`. The request never reached the gateway — it was rejected at Cloudflare's edge because GitHub-hosted runners egress from public Azure IPs that aren't allowlisted for the internal gateway.

Running on a self-hosted runner inside Deriv's network reaches the internal gateway without crossing the public Cloudflare edge, resolving the 403.

## Testing

- YAML parses cleanly; `runs-on` resolves to `{group: github_claude_code_reviewer}`.
- End-to-end verification requires a real run on a PR (the runner group must exist and be available to repos consuming this reusable workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)