### PR TITLE
fix(ci): check deriv-com org membership in Claude PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,7 +53,7 @@ jobs:
           echo "🔒 Validating access for user: $ACTOR"
 
           MEMBERSHIP=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/orgs/regentmarkets/members/$ACTOR" -w "%{http_code}" -o /dev/null)
+            "https://api.github.com/orgs/deriv-com/members/$ACTOR" -w "%{http_code}" -o /dev/null)
           [[ "$MEMBERSHIP" == "204" ]] && echo "✅ Verified org member" && exit 0
 
           COLLAB=$(curl -s -H "Authorization: token $GH_TOKEN" \


### PR DESCRIPTION
The Claude PR review security gate was validating against `regentmarkets`, causing deriv-com members to be denied unless they were explicit repo collaborators.

- Switch org membership check from `regentmarkets` to `deriv-com`
- Aligns with the existing `qa-checklist` workflow

Made with [Cursor](https://cursor.com)