### PR TITLE
ci: update default Claude model to Sonnet 5 in PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
       claude_model:
         description: "Claude model to use for review"
         required: false
-        default: "claude-sonnet-4-6"
+        default: "claude-sonnet-5"
         type: string
       prompt_gist_url:
         description: "URL to fetch prompt template from"
@@ -42,7 +42,7 @@ jobs:
       cancel-in-progress: true
 
     env:
-      CLAUDE_MODEL: ${{ inputs.claude_model || 'claude-sonnet-4-6' }}
+      CLAUDE_MODEL: ${{ inputs.claude_model || 'claude-sonnet-5' }}
 
     steps:
       - name: Security Check - Validate User Access


### PR DESCRIPTION
## Summary
Updates the default Claude model in the Claude PR Review workflow from `claude-sonnet-4-6` to `claude-sonnet-5`.

## Changes
- `.github/workflows/claude-pr-review.yml`
  - `claude_model` workflow_call input default: `claude-sonnet-4-6` → `claude-sonnet-5`
  - `CLAUDE_MODEL` env fallback: `claude-sonnet-4-6` → `claude-sonnet-5`

Callers can still override the model via the `claude_model` input.

Made with [Cursor](https://cursor.com)