### PR TITLE
feat: add archive-on-merge reusable workflow for openspec changes

### DIFF
--- a/.github/actions/archive_on_merge/README.md
+++ b/.github/actions/archive_on_merge/README.md
@@ -1,0 +1,36 @@
+# archive_on_merge
+
+Detects openspec change(s) completed by a merged PR, verifies every item in
+each change's `tasks.md` is checked, and runs `openspec archive --yes --json`.
+
+Prefer the reusable workflow for the full flow (detect + open archive PR):
+
+[`archive-on-merge.yml`](../../workflows/archive-on-merge.yml)
+
+## Composite action usage
+
+Requires the `openspec` CLI on `PATH` (install `@fission-ai/openspec` first)
+and a checkout of the consumer repo at the base branch with full history
+(`fetch-depth: 0`).
+
+```yaml
+- uses: deriv-com/shared-actions/.github/actions/archive_on_merge@master
+  id: archive
+  with:
+    base_sha: ${{ github.event.pull_request.base.sha }}
+    head_sha: ${{ github.event.pull_request.merge_commit_sha }}
+```
+
+### Inputs
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `base_sha` | yes | Base SHA of the merged PR (40-char hex) |
+| `head_sha` | yes | Merge commit SHA (40-char hex) |
+
+### Outputs
+
+| Name | Description |
+| --- | --- |
+| `archived` | `'true'` when at least one change was archived |
+| `changes` | Comma-separated kebab-case names that were archived |

--- a/.github/actions/archive_on_merge/README.md
+++ b/.github/actions/archive_on_merge/README.md
@@ -32,5 +32,5 @@ and a checkout of the consumer repo at the base branch with full history
 
 | Name | Description |
 | --- | --- |
-| `archived` | `'true'` when at least one change was archived |
-| `changes` | Comma-separated kebab-case names that were archived |
+| `archived` | `'true'` when at least one change was archived, otherwise `'false'` |
+| `changes` | Comma-separated kebab-case names that were archived (empty when none) |

--- a/.github/actions/archive_on_merge/action.yml
+++ b/.github/actions/archive_on_merge/action.yml
@@ -1,0 +1,33 @@
+name: archive_on_merge
+description: >
+  Detect openspec change(s) completed by a merge, verify every tasks.md item
+  is checked, and run `openspec archive --yes --json`. Emits outputs used by
+  a follow-up step/workflow that opens the archive PR (never pushes to a
+  protected branch).
+inputs:
+  base_sha:
+    description: Base SHA of the merged PR (40-char hex)
+    required: true
+  head_sha:
+    description: Merge commit SHA of the merged PR (40-char hex)
+    required: true
+outputs:
+  archived:
+    description: "'true' when at least one change was archived, otherwise 'false'"
+    value: ${{ steps.archive.outputs.archived }}
+  changes:
+    description: Comma-separated kebab-case change names that were archived
+    value: ${{ steps.archive.outputs.changes }}
+runs:
+  using: composite
+  steps:
+    - name: Detect + archive completed changes
+      id: archive
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base_sha }}
+        HEAD_SHA: ${{ inputs.head_sha }}
+        # openspec telemetry auto-disables when CI=true; set DO_NOT_TRACK too
+        # as defense-in-depth and for local runs outside CI.
+        DO_NOT_TRACK: "1"
+      run: node "${{ github.action_path }}/archive-on-merge.js"

--- a/.github/actions/archive_on_merge/action.yml
+++ b/.github/actions/archive_on_merge/action.yml
@@ -16,7 +16,7 @@ outputs:
     description: "'true' when at least one change was archived, otherwise 'false'"
     value: ${{ steps.archive.outputs.archived }}
   changes:
-    description: Comma-separated kebab-case change names that were archived
+    description: Comma-separated kebab-case change names that were archived (empty when none)
     value: ${{ steps.archive.outputs.changes }}
 runs:
   using: composite

--- a/.github/actions/archive_on_merge/archive-on-merge.js
+++ b/.github/actions/archive_on_merge/archive-on-merge.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// When the PR completing an openspec change is merged, archive that change.
+// Shared across repos via deriv-com/shared-actions (composite action +
+// reusable workflow).
+//
+// Detects which change(s) a merge touched from the diff, verifies every task
+// in that change's tasks.md is checked, then runs `openspec archive --yes
+// --json` (non-interactive). The calling workflow opens a follow-up PR with
+// the result — it never pushes directly to a protected branch.
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Prefer GITHUB_WORKSPACE so this script works when shipped as a composite
+// action (action files live under github.action_path, not the consumer repo).
+const ROOT = process.env.GITHUB_WORKSPACE || path.join(__dirname, "..");
+
+/**
+ * Given a list of changed file paths (e.g. from `git diff --name-only`),
+ * return the distinct openspec change names touched, excluding the archive
+ * directory itself. Pure function — no I/O.
+ */
+// Change directory names are kebab-case (e.g. "loop-automation-glue") — this
+// also guards against a path-traversal value (e.g. "..") ever being treated
+// as a change name below, since it can never match this pattern.
+const CHANGE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+// Full 40-char hex git SHA. GitHub always provides base/head SHAs in this
+// shape for a pull_request event, but validating the shape here is cheap
+// defense-in-depth before shelling out to `git diff` with them.
+const SHA_RE = /^[0-9a-f]{40}$/i;
+
+/** True when `value` is a well-formed 40-char hex git SHA. Pure function. */
+function isValidSha(value) {
+  return typeof value === "string" && SHA_RE.test(value);
+}
+
+function extractChangeNames(files) {
+  const names = [];
+  for (const f of files) {
+    const match = f.match(/^openspec\/changes\/([^/]+)\//);
+    const name = match && match[1];
+    if (
+      name &&
+      name !== "archive" &&
+      CHANGE_NAME_RE.test(name) &&
+      !names.includes(name)
+    ) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * True when a tasks.md body has no remaining `- [ ]` items, including nested
+ * sub-tasks indented under a parent item (valid GitHub Markdown). Pure
+ * function.
+ */
+function isTasksComplete(tasksMdContent) {
+  return !/^\s*-\s\[\s\]/m.test(tasksMdContent);
+}
+
+function gitDiffNames(base, head) {
+  const raw = execFileSync("git", ["diff", "--name-only", `${base}..${head}`], {
+    encoding: "utf8",
+  });
+  return raw.split("\n").filter(Boolean);
+}
+
+function runOpenspecArchive(changeName) {
+  try {
+    const raw = execFileSync(
+      "openspec",
+      ["archive", changeName, "--yes", "--json"],
+      {
+        encoding: "utf8",
+        cwd: ROOT,
+      }
+    );
+    return JSON.parse(raw);
+  } catch (err) {
+    // openspec exits non-zero on failure but still prints JSON to stdout.
+    const stdout = err.stdout ? err.stdout.toString() : "";
+    try {
+      return JSON.parse(stdout);
+    } catch (_parseErr) {
+      throw err;
+    }
+  }
+}
+
+function main() {
+  const base = process.env.BASE_SHA;
+  const head = process.env.HEAD_SHA;
+  if (!base || !head) {
+    console.error("BASE_SHA and HEAD_SHA env vars are required.");
+    process.exit(1);
+  }
+  if (!isValidSha(base) || !isValidSha(head)) {
+    console.error(
+      `BASE_SHA and HEAD_SHA must be 40-char hex SHAs (got '${base}', '${head}').`
+    );
+    process.exit(1);
+  }
+
+  const changedFiles = gitDiffNames(base, head);
+  const candidates = extractChangeNames(changedFiles);
+
+  if (candidates.length === 0) {
+    console.log(
+      "No openspec change directories touched by this merge. Nothing to archive."
+    );
+    return;
+  }
+
+  const archived = [];
+  for (const name of candidates) {
+    // Fault-isolated per candidate: an unexpected failure archiving one
+    // change (e.g. a merge that touches two changes at once) must not lose
+    // the result of another candidate that already succeeded in this run.
+    try {
+      const tasksPath = path.join(
+        ROOT,
+        "openspec",
+        "changes",
+        name,
+        "tasks.md"
+      );
+      if (!fs.existsSync(tasksPath)) {
+        console.log(
+          `'${name}' has no tasks.md — skipping (nothing to verify completion against).`
+        );
+        continue;
+      }
+      const content = fs.readFileSync(tasksPath, "utf8");
+      if (!isTasksComplete(content)) {
+        console.log(
+          `'${name}' still has incomplete tasks — not archiving yet.`
+        );
+        continue;
+      }
+
+      console.log(`'${name}' is complete — archiving...`);
+      const result = runOpenspecArchive(name);
+      if (!result.archive) {
+        const messages = (result.status || []).map((s) => s.message).join("; ");
+        console.log(
+          `openspec archive failed for '${name}': ${messages || "unknown error"}`
+        );
+        continue;
+      }
+      console.log(`Archived '${name}' -> ${result.archive.archivedAs}`);
+      archived.push(result.archive);
+    } catch (err) {
+      console.log(
+        `Unexpected error archiving '${name}': ${err.message}. Skipping.`
+      );
+    }
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    // `a.change` comes from openspec's own JSON response, not from our
+    // validated `name` input — re-validate against the same kebab-case
+    // allowlist before writing it to the GITHUB_OUTPUT file, so a malformed
+    // value (e.g. containing a newline) can't inject extra output keys.
+    const safeChanges = archived
+      .map((a) => a.change)
+      .filter((c) => CHANGE_NAME_RE.test(c))
+      .join(",");
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `archived=${archived.length > 0}\nchanges=${safeChanges}\n`
+    );
+  }
+}
+
+module.exports = {
+  extractChangeNames,
+  isTasksComplete,
+  isValidSha,
+  gitDiffNames,
+  runOpenspecArchive,
+  main,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/.github/actions/archive_on_merge/archive-on-merge.js
+++ b/.github/actions/archive_on_merge/archive-on-merge.js
@@ -13,7 +13,9 @@ const path = require("path");
 
 // Prefer GITHUB_WORKSPACE so this script works when shipped as a composite
 // action (action files live under github.action_path, not the consumer repo).
-const ROOT = process.env.GITHUB_WORKSPACE || path.join(__dirname, "..");
+// Fallback: three levels up from .github/actions/archive_on_merge → repo root.
+const ROOT =
+  process.env.GITHUB_WORKSPACE || path.join(__dirname, "..", "..", "..");
 
 /**
  * Given a list of changed file paths (e.g. from `git diff --name-only`),
@@ -64,6 +66,7 @@ function isTasksComplete(tasksMdContent) {
 function gitDiffNames(base, head) {
   const raw = execFileSync("git", ["diff", "--name-only", `${base}..${head}`], {
     encoding: "utf8",
+    cwd: ROOT,
   });
   return raw.split("\n").filter(Boolean);
 }
@@ -90,6 +93,28 @@ function runOpenspecArchive(changeName) {
   }
 }
 
+/**
+ * Write composite/workflow step outputs. Always emits `archived` (true/false)
+ * so callers can branch on either value, including the no-candidates path.
+ */
+function writeOutputs(archived) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+  // `a.change` comes from openspec's own JSON response, not from our
+  // validated `name` input — re-validate against the same kebab-case
+  // allowlist before writing it to the GITHUB_OUTPUT file, so a malformed
+  // value (e.g. containing a newline) can't inject extra output keys.
+  const safeChanges = archived
+    .map((a) => a.change)
+    .filter((c) => CHANGE_NAME_RE.test(c))
+    .join(",");
+  fs.appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `archived=${archived.length > 0}\nchanges=${safeChanges}\n`
+  );
+}
+
 function main() {
   const base = process.env.BASE_SHA;
   const head = process.env.HEAD_SHA;
@@ -111,10 +136,12 @@ function main() {
     console.log(
       "No openspec change directories touched by this merge. Nothing to archive."
     );
+    writeOutputs([]);
     return;
   }
 
   const archived = [];
+  let archiveFailures = 0;
   for (const name of candidates) {
     // Fault-isolated per candidate: an unexpected failure archiving one
     // change (e.g. a merge that touches two changes at once) must not lose
@@ -148,6 +175,7 @@ function main() {
         console.log(
           `openspec archive failed for '${name}': ${messages || "unknown error"}`
         );
+        archiveFailures += 1;
         continue;
       }
       console.log(`Archived '${name}' -> ${result.archive.archivedAs}`);
@@ -156,22 +184,20 @@ function main() {
       console.log(
         `Unexpected error archiving '${name}': ${err.message}. Skipping.`
       );
+      archiveFailures += 1;
     }
   }
 
-  if (process.env.GITHUB_OUTPUT) {
-    // `a.change` comes from openspec's own JSON response, not from our
-    // validated `name` input — re-validate against the same kebab-case
-    // allowlist before writing it to the GITHUB_OUTPUT file, so a malformed
-    // value (e.g. containing a newline) can't inject extra output keys.
-    const safeChanges = archived
-      .map((a) => a.change)
-      .filter((c) => CHANGE_NAME_RE.test(c))
-      .join(",");
-    fs.appendFileSync(
-      process.env.GITHUB_OUTPUT,
-      `archived=${archived.length > 0}\nchanges=${safeChanges}\n`
+  writeOutputs(archived);
+
+  // Soft-skip (incomplete / no tasks.md) is success. But if every attempt to
+  // archive a completed change failed, exit non-zero so CI does not go green
+  // while leaving finished changes unarchived.
+  if (archived.length === 0 && archiveFailures > 0) {
+    console.error(
+      `Failed to archive ${archiveFailures} completed change(s); see logs above.`
     );
+    process.exit(1);
   }
 }
 
@@ -181,6 +207,7 @@ module.exports = {
   isValidSha,
   gitDiffNames,
   runOpenspecArchive,
+  writeOutputs,
   main,
 };
 

--- a/.github/workflows/archive-on-merge.yml
+++ b/.github/workflows/archive-on-merge.yml
@@ -1,0 +1,151 @@
+name: Archive on Merge
+
+# Reusable workflow: when a merged PR completes an openspec change (every task
+# checked), run `openspec archive --yes --json` and open a follow-up PR moving
+# it to openspec/changes/archive/. Never pushes directly to a protected branch;
+# a human still merges the archive PR.
+#
+# Caller example (thin wrapper in the consumer repo):
+#
+#   name: Archive on Merge
+#   on:
+#     pull_request:
+#       types: [closed]
+#       branches: [master]
+#   permissions:
+#     contents: write
+#     pull-requests: write
+#   jobs:
+#     archive:
+#       if: github.event.pull_request.merged == true
+#       uses: deriv-com/shared-actions/.github/workflows/archive-on-merge.yml@master
+#       permissions:
+#         contents: write
+#         pull-requests: write
+
+on:
+  workflow_call:
+    inputs:
+      base_branch:
+        description: Base branch to check out and target for the archive PR
+        required: false
+        default: "master"
+        type: string
+      node_version:
+        description: Node.js version for the openspec CLI
+        required: false
+        default: "22"
+        type: string
+      openspec_version:
+        description: Pinned @fission-ai/openspec version installed for the archive CLI
+        required: false
+        default: "1.6.0"
+        type: string
+      action_ref:
+        description: >
+          Git ref of shared-actions used to fetch the archive_on_merge script
+          (keep in sync with the workflow ref you call, e.g. master)
+        required: false
+        default: "master"
+        type: string
+
+jobs:
+  archive:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    concurrency:
+      group: archive-on-merge-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.base_branch }}
+
+      # Fetch the archive script from shared-actions at the same ref the caller
+      # pinned (default master). A second checkout is required because a
+      # reusable workflow cannot resolve a same-repo composite action via a
+      # relative `uses: ./` path when invoked cross-repo (that path is relative
+      # to the *caller*), and `uses:` does not accept `${{ }}` expressions.
+      - name: Fetch archive-on-merge script
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: deriv-com/shared-actions
+          ref: ${{ inputs.action_ref }}
+          path: .shared-actions
+          sparse-checkout: |
+            .github/actions/archive_on_merge
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Install openspec CLI
+        env:
+          OPENSPEC_VERSION: ${{ inputs.openspec_version }}
+        run: npm install -g "@fission-ai/openspec@${OPENSPEC_VERSION}"
+
+      - name: Detect + archive completed changes
+        id: archive
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          # openspec telemetry auto-disables when CI=true; set DO_NOT_TRACK too
+          # as defense-in-depth and for local runs outside CI.
+          DO_NOT_TRACK: "1"
+        run: node .shared-actions/.github/actions/archive_on_merge/archive-on-merge.js
+
+      - name: Remove shared-actions checkout
+        if: always()
+        run: rm -rf .shared-actions
+
+      - name: Open archive PR
+        if: steps.archive.outputs.archived == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGES: ${{ steps.archive.outputs.changes }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          BRANCH="archive-on-merge/$PR_NUMBER"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Idempotency: skip if a PR for this branch is already open.
+          # `// empty` (rather than bare `.[0].number`) matters here: on no
+          # match, `.[0]` is `null` and `.number` on `null` is still `null`,
+          # which `jq` prints as the *string* "null" — truthy to `[ -n ]`.
+          EXISTING=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open for $BRANCH — skipping."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH"
+          git add openspec/
+
+          # Guard against the edge case where `openspec archive` reported
+          # success but staged no filesystem changes — `git commit` would
+          # otherwise fail with a cryptic "nothing to commit" error.
+          if git diff --cached --quiet; then
+            echo "openspec archive reported success but staged no changes — nothing to push."
+            exit 0
+          fi
+
+          git commit -m "docs(openspec): archive completed change(s) - $CHANGES"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "docs(openspec): archive completed change(s) - $CHANGES" \
+            --body "Automated archive triggered by the merge of #${PR_NUMBER}. Moves ${CHANGES} to \`openspec/changes/archive/\` and syncs specs, per \`openspec archive --yes\`." \
+            --base "$BASE_BRANCH" \
+            --head "$BRANCH"

--- a/.github/workflows/archive-on-merge.yml
+++ b/.github/workflows/archive-on-merge.yml
@@ -19,6 +19,9 @@ name: Archive on Merge
 #     archive:
 #       if: github.event.pull_request.merged == true
 #       uses: deriv-com/shared-actions/.github/workflows/archive-on-merge.yml@master
+#       with:
+#         # Must match the workflow ref above (master / tag / sha).
+#         action_ref: master
 #       permissions:
 #         contents: write
 #         pull-requests: write
@@ -43,10 +46,10 @@ on:
         type: string
       action_ref:
         description: >
-          Git ref of shared-actions used to fetch the archive_on_merge script
-          (keep in sync with the workflow ref you call, e.g. master)
-        required: false
-        default: "master"
+          Git ref of shared-actions used to fetch the archive_on_merge script.
+          Required — must match the workflow ref in your `uses:` pin (e.g.
+          master, a tag, or a commit SHA) so the script cannot drift.
+        required: true
         type: string
 
 jobs:
@@ -69,11 +72,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.base_branch }}
 
-      # Fetch the archive script from shared-actions at the same ref the caller
-      # pinned (default master). A second checkout is required because a
-      # reusable workflow cannot resolve a same-repo composite action via a
-      # relative `uses: ./` path when invoked cross-repo (that path is relative
-      # to the *caller*), and `uses:` does not accept `${{ }}` expressions.
+      # Fetch the archive script from shared-actions at the caller-supplied
+      # action_ref (must match the workflow `uses:` pin). A second checkout is
+      # required because a reusable workflow cannot resolve a same-repo
+      # composite action via a relative `uses: ./` path when invoked cross-repo
+      # (that path is relative to the *caller*), and `uses:` does not accept
+      # `${{ }}` expressions.
       - name: Fetch archive-on-merge script
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -129,6 +133,11 @@ jobs:
             echo "PR #$EXISTING already open for $BRANCH — skipping."
             exit 0
           fi
+
+          # No open PR uses this branch — drop any stale remote left from a
+          # closed-without-merge archive PR so re-runs are not blocked by a
+          # non-fast-forward push.
+          git push origin --delete "$BRANCH" 2>/dev/null || true
 
           git checkout -b "$BRANCH"
           git add openspec/

--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ jobs:
   archive:
     if: github.event.pull_request.merged == true
     uses: deriv-com/shared-actions/.github/workflows/archive-on-merge.yml@master
+    with:
+      # Required — must match the workflow ref in `uses:` above.
+      action_ref: master
     permissions:
       contents: write
       pull-requests: write
 ```
 
-Optional inputs: `base_branch` (default `master`), `node_version` (default
-`22`), `openspec_version` (default `1.6.0`), `action_ref` (default `master` —
-keep in sync with the workflow ref you call).
+Required input: `action_ref` (same ref as the workflow `uses:` pin). Optional:
+`base_branch` (default `master`), `node_version` (default `22`),
+`openspec_version` (default `1.6.0`).
 
 The detect/archive script is also available as a composite action:
 [`archive_on_merge`](.github/actions/archive_on_merge/).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,35 @@ This repository is dedicated to hosting reusable GitHub Actions YAML files that 
           issue_number: ${{steps.pr_information.outputs.issue_number}}
           head_sha: ${{github.event.workflow_run.head_sha}}
 ```
+
+### Archive on Merge (openspec)
+
+When a PR that completes an openspec change merges, archive it and open a
+follow-up PR (never pushes directly to a protected branch).
+
+Thin caller in the consumer repo:
+
+```yaml
+name: Archive on Merge
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  archive:
+    if: github.event.pull_request.merged == true
+    uses: deriv-com/shared-actions/.github/workflows/archive-on-merge.yml@master
+    permissions:
+      contents: write
+      pull-requests: write
+```
+
+Optional inputs: `base_branch` (default `master`), `node_version` (default
+`22`), `openspec_version` (default `1.6.0`), `action_ref` (default `master` —
+keep in sync with the workflow ref you call).
+
+The detect/archive script is also available as a composite action:
+[`archive_on_merge`](.github/actions/archive_on_merge/).


### PR DESCRIPTION
## Summary
- Adds a reusable **Archive on Merge** workflow so any openspec-using repo can archive completed changes when their completing PR merges.
- Ships the detect/archive Node script as the `archive_on_merge` composite action (uses `GITHUB_WORKSPACE` so it works outside the consumer's `scripts/` tree).
- Opens a follow-up archive PR only — never pushes directly to a protected branch. Includes idempotency (`gh pr list … // empty`) and empty-staging guards from the deriv-blox implementation.

## Consumer usage

```yaml
name: Archive on Merge
on:
  pull_request:
    types: [closed]
    branches: [master]
permissions:
  contents: write
  pull-requests: write
jobs:
  archive:
    if: github.event.pull_request.merged == true
    uses: deriv-com/shared-actions/.github/workflows/archive-on-merge.yml@master
    permissions:
      contents: write
      pull-requests: write
```

Optional inputs: `base_branch`, `node_version`, `openspec_version`, `action_ref` (keep in sync with the workflow ref).

## Test plan
- [ ] `actionlint` on `.github/workflows/archive-on-merge.yml` is clean
- [ ] Review composite action inputs/outputs and script `ROOT` (`GITHUB_WORKSPACE`)
- [ ] After merge, wire a thin caller in a consumer repo (e.g. deriv-blox) and merge a completing openspec change to confirm the archive PR opens
- [ ] Re-run the workflow on the same PR number and confirm the idempotency guard skips creating a duplicate


Made with [Cursor](https://cursor.com)