### PR TITLE
fix: match review comments by marker, not every bot comment

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -242,11 +242,18 @@ jobs:
             | jq -s 'add' > /tmp/all_comments.json
 
           # Substring matching, not regex, so marker content needs no escaping.
+          #
+          # The marker MUST be captured with `. as $marker` before piping into
+          # `$body`. Writing the condition as `$body | contains(.)` looks right but
+          # rebinds `.` to $body inside the pipe, making it `$body contains $body`
+          # — always true. That silently matched EVERY github-actions[bot] comment
+          # on the PR, so the delete loop below would reap unrelated bot comments
+          # (DocSync, QA checklist, ...) instead of just prior reviews.
           FILTER='
             ($ENV.REVIEW_MARKERS | split("\n") | map(select(length > 0))) as $markers
             | map(select(
                 .user.login == "github-actions[bot]"
-                and (.body as $b | any($markers[]; $b | contains(.)))
+                and (.body as $body | any($markers[]; . as $marker | $body | contains($marker)))
               ))
             | sort_by(.created_at)
           '


### PR DESCRIPTION
## Summary

The comment-cleanup step in `ai-pr-review.yml` deletes **every** `github-actions[bot]` comment on a PR, not just prior AI reviews. Found while wiring up the first real consumer ([deriv-api-v2#566](https://github.com/deriv-com/deriv-api-v2/pull/566)).

## Cause

A jq scoping mistake introduced with multi-marker matching:

```jq
any($markers[]; $body | contains(.))
```

The `$body |` pipe **rebinds `.` to `$body`** inside the condition, so it evaluates as `$body contains $body` — always true, regardless of the marker list. Capturing the marker first fixes it:

```jq
any($markers[]; . as $marker | $body | contains($marker))
```

## Impact

Every review run would have deleted unrelated bot comments on the PR: DocSync AI, QA checklist, and — worst — `Click2Fix - Acknowledge` comments. Cleanup runs *before* the acknowledge scan, so the acknowledge feature would have silently stopped working, with suggestions the developer had dismissed reappearing in every review.

It also made `legacy_markers` meaningless: emptying it had no effect, because everything matched anyway.

**Not yet fired.** Nothing calls `ai-pr-review.yml` yet (only the README references it), so no comments have been lost. It would have hit on the first consumer.

## Verification

Ran the filter exactly as the workflow defines it against a six-comment fixture:

| Comment | `legacy_markers: ""` | default `legacy_markers` |
|---|---|---|
| Claude review | survives ✅ | deleted ✅ |
| AI review (own) | deleted ✅ | deleted ✅ |
| DocSync AI | survives ✅ | survives ✅ |
| QA checklist | survives ✅ | survives ✅ |
| Click2Fix Acknowledge | survives ✅ | survives ✅ |
| Human comment quoting the marker | survives ✅ | survives ✅ |

Before the fix, all five bot comments were deleted in both modes.

## Test plan

- [x] `yaml-lint` and `actionlint` clean
- [x] Filter verified against the fixture above in both marker modes
- [ ] Confirm on the first real run that only the prior AI review is removed

> Blocks [deriv-api-v2#566](https://github.com/deriv-com/deriv-api-v2/pull/566), which runs Kimi and Claude side by side and relies on `legacy_markers: ""` actually sparing the Claude comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)