### PR TITLE
fix: remove empty Actions expression that broke the Kimi engine manifest

### DIFF
--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -184,9 +184,14 @@ runs:
         export KIMI_MODEL_BASE_URL="$BASE_URL"
         echo "🔧 Kimi engine | model=$KIMI_MODEL_NAME | base_url=$BASE_URL"
 
-        # Quoted heredoc: the ${{ }} expressions below are substituted by Actions
-        # before bash sees this script, so no shell expansion happens in the
-        # prompt body.
+        # Quoted heredoc: the inputs.* expressions below are substituted by
+        # Actions before bash sees this script, so no shell expansion happens in
+        # the prompt body.
+        #
+        # Do NOT write an empty expression pair in this block. Actions scans the
+        # whole run: string for expressions, including text bash treats as a
+        # comment, and an empty one fails manifest validation before any step
+        # runs — which is exactly how this file got broken once already.
         cat > /tmp/review_prompt.txt <<'EOF'
         REPO: ${{ inputs.repository }}
         PR NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
## The failure

Every `engine: kimi` run fails at **Set up job**, before a single step executes — e.g. [deriv-api-v2 run 31579364467](https://github.com/deriv-com/deriv-api-v2/actions/runs/31579364467/job/94058694723):

```
##[error]deriv-com/shared-actions/master/.github/actions/ai_review_engine_kimi/action.yml
        (Line: 176, Col: 12): An expression was expected
##[error]Failed to load .../ai_review_engine_kimi/action.yml
```

## Cause

An explanatory comment inside the `run:` block contained a **literal empty expression pair**:

```bash
# Quoted heredoc: the ${‌{ }} expressions below are substituted by Actions
```

Bash treats that line as a comment, but Actions template-scans the *entire* `run:` string for expressions — it does not know or care that bash would ignore it. An empty expression fails manifest validation, so the action never loads.

The reported position (line 176, col 12) is the **start of the block scalar**, not the offending line, which makes it read like a YAML indentation problem rather than a stray expression ~11 lines further down.

## Fix

Reworded to describe the expressions without writing an empty pair, plus an inline warning so the next editor doesn't reintroduce it.

## Why it reached master

Two gaps, both worth knowing:

- **`yaml-lint` passes** — it *is* valid YAML. The text is just a string inside a block scalar.
- **`actionlint` never sees it.** It validates `.github/workflows/` only; passing an `action.yml` makes it try to parse the file as a workflow and emit unrelated "jobs section is missing" noise. **Nothing in this repo validates composite action manifests.**

So both engine actions are currently unlinted. I verified by hand that neither has any remaining empty expression (kimi: 19 expressions, anthropic: 17, zero empty) and that both are valid YAML — but that check was manual.

## Suggested follow-up (not in this PR)

A tiny CI job on `.github/actions/**/action.yml` that fails on empty expression pairs would have caught this in seconds. Worth adding given nothing else covers these files. Happy to open it separately.

## Test plan

- [x] No empty expressions remain in either engine action
- [x] Both action manifests are valid YAML
- [ ] Re-run a Kimi review on deriv-api-v2 and confirm it gets past **Set up job**

🤖 Generated with [Claude Code](https://claude.com/claude-code)