### PR TITLE
fix: default the kimi engine to the LiteLLM alias kimi-k3, and surface provider errors

### DIFF
--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -223,15 +223,35 @@ runs:
         # so the actual provider request and response body are unrecoverable.
         # Secrets registered with the job are masked in these logs by Actions.
         dump_kimi_log() {
-          echo "::group::kimi-code.log (last 200 lines)"
-          tail -n 200 "$HOME/.kimi-code/logs/kimi-code.log" 2>/dev/null \
-            || echo "(no log at $HOME/.kimi-code/logs/kimi-code.log)"
+          KIMI_LOG="$HOME/.kimi-code/logs/kimi-code.log"
+          KIMI_LOG_LINES=0
+          # tr strips the leading padding BSD wc emits, so the count reads cleanly
+          # if this is ever run outside the Linux runner.
+          [[ -f "$KIMI_LOG" ]] && KIMI_LOG_LINES=$(wc -l < "$KIMI_LOG" | tr -d '[:space:]')
+
+          echo "::group::kimi-code.log (showing last 200 of $KIMI_LOG_LINES lines)"
+          if [[ -f "$KIMI_LOG" ]]; then
+            tail -n 200 "$KIMI_LOG"
+          else
+            echo "(no log at $KIMI_LOG)"
+          fi
           echo "::endgroup::"
+
+          # State the truncation explicitly. Silent truncation would defeat the
+          # point of dumping the log at all: if the provider error scrolls past
+          # the window, the reader needs to know the tail is not the whole story.
+          if [[ "$KIMI_LOG_LINES" -gt 200 ]]; then
+            echo "⚠️  Log is $KIMI_LOG_LINES lines and only the last 200 are shown."
+            echo "    If the provider request/response is not visible above, raise the tail window."
+          fi
+
           echo "ℹ️  Resolved provider config: model=$KIMI_MODEL_NAME base_url=$KIMI_MODEL_BASE_URL provider_type=$KIMI_MODEL_PROVIDER_TYPE"
           echo "ℹ️  A 400 from the proxy most often means \`model\` is not a name it fronts."
           echo "    The Kimi-platform ids (k3, k3-256k, kimi-for-coding) are valid at"
           echo "    api.kimi.com/coding/v1, NOT necessarily on a LiteLLM proxy, which uses"
-          echo "    whatever aliases it was configured with. List them with:"
+          echo "    whatever aliases it was configured with. To list them, run this on your"
+          echo "    own machine with the same key you passed as LLM_API_KEY (that variable is"
+          echo "    deliberately not set in this job, so the line below is a template):"
           echo "      curl -H \"Authorization: Bearer \$LLM_API_KEY\" $KIMI_MODEL_BASE_URL/models"
         }
 

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -41,9 +41,10 @@ inputs:
     description: "Number of the PR under review (prompt preamble only)."
     required: true
   model:
-    description: "Model ID — k3, k3-256k, kimi-for-coding, kimi-for-coding-highspeed, or any model the LiteLLM proxy fronts. Maps to KIMI_MODEL_NAME."
+    description: "Model ID as the endpoint in base_url names it. With the LiteLLM proxy that is a proxy alias, e.g. `kimi-k3`. The Kimi-platform ids (`k3`, `k3-256k`, `kimi-for-coding`, `kimi-for-coding-highspeed`) only resolve against api.kimi.com/coding/v1 and return 400 from the proxy. Maps to KIMI_MODEL_NAME."
     required: false
-    default: "k3"
+    # Matches the default base_url below, which is the LiteLLM proxy.
+    default: "kimi-k3"
   base_url:
     description: "LLM API base URL. A trailing /v1 is appended when absent, so the identical value also works for the anthropic engine (which needs it removed). Maps to KIMI_MODEL_BASE_URL."
     required: false
@@ -52,7 +53,7 @@ inputs:
     description: "API key for base_url. Composite actions cannot read the `secrets` context, so the caller must pass this explicitly. Maps to KIMI_MODEL_API_KEY and is never written to disk."
     required: true
   max_context_size:
-    description: "Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Must match the selected model, or the CLI over-packs context and the API rejects the request. Maps to KIMI_MODEL_MAX_CONTEXT_SIZE."
+    description: "Maximum context window in tokens. Must not exceed what the endpoint allows for the selected model, or the CLI over-packs context and the request is rejected. K3 is 1048576; the 256k variants are 262144. If a 400 persists after confirming the model name, try lowering this. Maps to KIMI_MODEL_MAX_CONTEXT_SIZE."
     required: false
     default: "1048576"
   provider_type:

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -216,16 +216,41 @@ runs:
            The caller posts that file as a single PR comment.
         EOF
 
+        # Dumps the CLI's own log on failure. Without this the step reports only
+        # the CLI's one-line summary (e.g. "provider.api_error: 400 The request
+        # was invalid") and points at a log file on a runner that is already gone,
+        # so the actual provider request and response body are unrecoverable.
+        # Secrets registered with the job are masked in these logs by Actions.
+        dump_kimi_log() {
+          echo "::group::kimi-code.log (last 200 lines)"
+          tail -n 200 "$HOME/.kimi-code/logs/kimi-code.log" 2>/dev/null \
+            || echo "(no log at $HOME/.kimi-code/logs/kimi-code.log)"
+          echo "::endgroup::"
+          echo "ℹ️  Resolved provider config: model=$KIMI_MODEL_NAME base_url=$KIMI_MODEL_BASE_URL provider_type=$KIMI_MODEL_PROVIDER_TYPE"
+          echo "ℹ️  A 400 from the proxy most often means \`model\` is not a name it fronts."
+          echo "    The Kimi-platform ids (k3, k3-256k, kimi-for-coding) are valid at"
+          echo "    api.kimi.com/coding/v1, NOT necessarily on a LiteLLM proxy, which uses"
+          echo "    whatever aliases it was configured with. List them with:"
+          echo "      curl -H \"Authorization: Bearer \$LLM_API_KEY\" $KIMI_MODEL_BASE_URL/models"
+        }
+
         # No GitHub token in this step's env and no Bash tool in the config: the
         # agent cannot reach the GitHub API at all. The caller's post step is the
         # only thing that can comment on the PR.
-        kimi -p "$(cat /tmp/review_prompt.txt)"
+        kimi -p "$(cat /tmp/review_prompt.txt)" && KIMI_STATUS=0 || KIMI_STATUS=$?
+
+        if [[ "$KIMI_STATUS" -ne 0 ]]; then
+          echo "❌ Kimi engine: CLI exited $KIMI_STATUS"
+          dump_kimi_log
+          exit "$KIMI_STATUS"
+        fi
 
         # Fail here, named, rather than letting the caller report a generic
         # "review file missing" — all steps in a composite action share one log
         # group, so an engine-attributed error is what makes this locatable.
         if [[ ! -s "$OUTPUT_PATH" ]]; then
           echo "❌ Kimi engine: the CLI finished but wrote no review to $OUTPUT_PATH"
+          dump_kimi_log
           exit 1
         fi
         echo "✅ Kimi engine: review written ($(wc -c < "$OUTPUT_PATH") bytes)"

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -61,7 +61,7 @@ from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
 | | `kimi` | `anthropic` |
 |---|---|---|
 | Runtime | `@moonshot-ai/kimi-code` CLI (npm, pinned) | `anthropics/claude-code-action` (pinned by SHA) |
-| Default model | `k3` | `claude-sonnet-5` |
+| Default model | `kimi-k3` | `claude-sonnet-5` |
 | `base_url` sent | proxy origin **+ `/v1`** | proxy origin, **`/v1` stripped** |
 | Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` **+ the action's base GitHub tools** |
 | Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash) |
@@ -70,6 +70,20 @@ from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
 | Applicable inputs | all, incl. `max_context_size`, `cli_version` | all except `max_context_size`, `cli_version` |
 | `agent` reported | `ai_review` | `claude_review` |
 | Artifact | `ai-review-summary-*` | `claude-review-summary-*` |
+
+**Model names belong to the endpoint, not the model.** `model` is passed through
+verbatim, so it must be whatever the thing in `base_url` calls it. On the Deriv
+LiteLLM proxy K3 is `kimi-k3`; the Kimi-platform ids (`k3`, `k3-256k`,
+`kimi-for-coding`) resolve only against `api.kimi.com/coding/v1` and return a
+bare `400 The request was invalid` from the proxy. List what a proxy accepts:
+
+```bash
+curl -s https://litellmsa.deriv.ai/v1/models \
+  -H "Authorization: Bearer $LLM_API_KEY" | jq -r '.data[].id' | sort
+```
+
+If a 400 survives fixing the model name, suspect `max_context_size` exceeding
+the window the endpoint allows for that alias.
 
 **On the `/v1` asymmetry:** `base_url` is one engine-neutral input. The Kimi CLI
 wants a `/v1` suffix; the Anthropic SDK appends `/v1/messages` itself and must not
@@ -199,7 +213,7 @@ summary regardless of dashboard state:
   "agent": "ai_review",
   "event_type": "initial_review | followup_review",
   "timestamp": "…", "pr_number": "…", "repo": "…",
-  "payload": { "commit_sha": "…", "review_size_bytes": 0, "model": "k3", "engine": "kimi" }
+  "payload": { "commit_sha": "…", "review_size_bytes": 0, "model": "kimi-k3", "engine": "kimi" }
 }
 ```
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -31,7 +31,7 @@ on:
         default: "kimi"
         type: string
       model:
-        description: "Model ID to use for review. Defaults per engine (kimi -> k3, anthropic -> claude-sonnet-5). Any model the LiteLLM proxy fronts works."
+        description: "Model ID to use for review, as the endpoint in `base_url` names it. Defaults per engine (kimi -> kimi-k3, anthropic -> claude-sonnet-5). With the default LiteLLM base_url this must be a proxy alias — list them with `curl -H \"Authorization: Bearer $LLM_API_KEY\" https://litellmsa.deriv.ai/v1/models`. Kimi-platform ids such as `k3` only resolve against api.kimi.com/coding/v1."
         required: false
         default: ""
         type: string
@@ -41,7 +41,7 @@ on:
         default: "https://litellmsa.deriv.ai/v1"
         type: string
       max_context_size:
-        description: "[engine-specific: kimi] Maximum context window in tokens (k3 = 1048576, k3-256k / kimi-for-coding = 262144). Must match the model or the CLI over-packs context and the API rejects the request. Ignored when engine is not `kimi`."
+        description: "[engine-specific: kimi] Maximum context window in tokens. Must not exceed the window the endpoint actually allows for the selected model, or the CLI over-packs context and the request is rejected. K3 is 1048576; the 256k variants are 262144. If a request fails with a 400 after the model name is confirmed correct, try lowering this. Ignored when engine is not `kimi`."
         required: false
         default: "1048576"
         type: string
@@ -153,7 +153,10 @@ jobs:
           # so routing a repo onto this workflow must not rename it.
           case "$ENGINE" in
             kimi)
-              DEFAULT_MODEL="k3"
+              # LiteLLM alias, NOT the Kimi-platform id. The proxy fronts K3 as
+              # `kimi-k3`; `k3` only resolves at api.kimi.com/coding/v1 and gets
+              # a 400 from the proxy.
+              DEFAULT_MODEL="kimi-k3"
               METRICS_AGENT="ai_review"
               ARTIFACT_PREFIX="ai-review"
               ;;
@@ -327,8 +330,10 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           # Passed through env, never interpolated into the script below: the body
-          # is author-controlled, so `${{ }}` inline in a run block would let
-          # backticks or $(...) execute on the runner.
+          # is author-controlled, so an inline Actions expression in a run block
+          # would let backticks or $(...) execute on the runner.
+          # (Deliberately not spelling out an empty expression pair here — Actions
+          # scans run: blocks for those and fails the manifest, cf. PR #109.)
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Root cause

Every `engine: kimi` run failed with:

```
🔧 Kimi engine | model=k3 | base_url=https://litellmsa.deriv.ai/v1
error: failed to run prompt: provider.api_error: 400 The request was invalid.
```

**The model name was wrong for the endpoint.** `k3` is a Kimi Code *platform* id, valid at `api.kimi.com/coding/v1`. The default `base_url` is the Deriv LiteLLM proxy, which fronts K3 as **`kimi-k3`** (confirmed in the LiteLLM dashboard). The proxy rejects the unknown alias with a bare 400 — no mention of the model, which is why it read as a wire-format problem.

These two defaults were inherited together and never agreed: the advertised model list (`k3`, `k3-256k`, `kimi-for-coding`) came from the direct-Kimi endpoint docs, while `base_url` pointed at the proxy. Nothing had exercised the combination until deriv-api-v2 became the first real consumer.

Notably this was **not** the `KIMI_MODEL_PROVIDER_TYPE=kimi` wire-format incompatibility flagged as a risk throughout — auth and transport were fine all along (a 400, never a 401/403).

## Changes

**1. Correct the default** — `kimi-k3`, in both the workflow's resolve step and the engine action's own input default, with a comment on why.

**2. Fix the docs that caused it.** `model` now states that the value belongs to whatever endpoint `base_url` names, with the command to list a proxy's aliases:

```bash
curl -s https://litellmsa.deriv.ai/v1/models -H "Authorization: Bearer $LLM_API_KEY" | jq -r '.data[].id' | sort
```

`max_context_size` now says it must not exceed the window the endpoint allows for that alias, and is the next thing to suspect if a 400 survives fixing the model name. New "model names belong to the endpoint" section in the README.

**3. Surface the CLI log on failure** (original purpose of this PR). A failure previously printed only the CLI's one-line summary and pointed at `/home/runner/.kimi-code/logs/kimi-code.log` — on a runner destroyed with the job, so the provider's actual response body was unrecoverable. The step now dumps the log tail, echoes the resolved model/base_url/provider_type, and names the likely cause. That is how the next such failure gets diagnosed in one run instead of three.

**4. Remove an empty-expression footgun.** A YAML comment contained a literal empty `${‌{ }}` pair. Harmless there — YAML comments are stripped before Actions scans for expressions — but the identical text inside a `run:` block is exactly what broke the manifest in #109, so it is not worth leaving as a copy-paste hazard.

## Test plan

- [x] `yaml-lint` and `actionlint` clean; no empty expressions in either engine action
- [x] `run:` block verified as syntactically valid bash
- [x] No bare `k3` default remains
- [ ] Re-run the Kimi review on deriv-api-v2 and confirm it gets past the provider call
- [ ] If a 400 persists, read the newly-dumped log and check `max_context_size` against the proxy's configured window for `kimi-k3`

> Pairs with the caller update in [deriv-api-v2#566](https://github.com/deriv-com/deriv-api-v2/pull/566), which pins `model: kimi-k3` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)