### PR TITLE
fix: stop the Kimi diagnostic aborting when no log is found

### DIFF
--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -223,6 +223,12 @@ runs:
         # so the actual provider request and response body are unrecoverable.
         # Secrets registered with the job are masked in these logs by Actions.
         dump_kimi_log() {
+          # A diagnostic must never be killed by the thing it is diagnosing. The
+          # step runs under `bash -e -o pipefail`, so any non-zero command in here
+          # would abort the dump partway and hide the rest. Both call sites `exit`
+          # explicitly straight after, so relaxing this has no other effect.
+          set +e +o pipefail
+
           # Request shape first. A 400 whose body we cannot see is still narrowable
           # from the sizes: if the packed context approaches the window the proxy
           # allows for this alias, "context too large" is the likely cause rather
@@ -238,7 +244,14 @@ runs:
           # does not always create it, so search for whatever it did write instead
           # of reporting "no log" and giving up — that left the provider response
           # unrecoverable on the runs this function was added to diagnose.
-          KIMI_LOGS=$(find "$HOME" /tmp -maxdepth 5 -type f -name '*.log' 2>/dev/null | grep -i kimi | head -5)
+          #
+          # `|| true` is load-bearing: the step runs under `bash -e -o pipefail`,
+          # and grep exits 1 when it matches nothing. Without it, pipefail
+          # propagates that failure and set -e kills the script mid-diagnostic —
+          # aborting on exactly the no-log case this branch exists to report, and
+          # swallowing the narrowing hints below. That is what happened on the
+          # first run after this function shipped.
+          KIMI_LOGS=$(find "$HOME" /tmp -maxdepth 5 -type f -name '*.log' 2>/dev/null | grep -i kimi | head -5 || true)
 
           if [[ -n "$KIMI_LOGS" ]]; then
             while IFS= read -r log; do


### PR DESCRIPTION
## Problem

The diagnostics from #111 died partway through on their first real run ([job 94069931480](https://github.com/deriv-com/deriv-api-v2/actions/runs/31580026527/job/94069931480)). Output stopped dead after the size line:

```
❌ Kimi engine: CLI exited 1
ℹ️  Resolved provider config: model=k3 base_url=... provider_type=kimi
ℹ️  max_context_size declared to the CLI: 1048576 tokens
ℹ️  Input sizes in bytes: context=20074 diff=7826 prompt=1168
##[error]Process completed with exit code 1.
```

No log-hunt result, no `kimi --help` fallback, no narrowing hints.

## Cause

The step runs under `bash -e -o pipefail`, and:

```bash
KIMI_LOGS=$(find "$HOME" /tmp ... | grep -i kimi | head -5)
```

`grep` exits 1 when it matches nothing → `pipefail` propagates → `set -e` kills the script. So the dump aborted on **exactly the no-log case that branch was written to report**, and swallowed everything after it.

Reproduced under the same flags before fixing:

```
$ bash -e -o pipefail repro.sh
step 1: before
  exit=1          # "step 2: after" never printed
```

## Fix

Two independent guards, so neither has to be correct alone:

- `|| true` on the pipeline.
- `set +e +o pipefail` at the top of `dump_kimi_log`. A diagnostic must not be killed by the failure it is diagnosing; both call sites `exit` explicitly immediately after, so relaxing it changes nothing else.

Verified the function now runs to completion with no log present, under `bash -e -o pipefail`.

## What the partial output already told us

Not wasted — it ruled out one of the three candidate causes:

**`max_context_size` is not the problem.** Declared 1048576 tokens; actual input is `context=20074 + diff=7826 + prompt=1168` ≈ **29 KB, roughly 8K tokens**. Three orders of magnitude below the window. Size is cleared.

That leaves the model alias and the request wire format — and `model=k3` in this run is a red herring, see below.

## Note: `model=k3` here is a stale queued run, not a regression

This run was **created 08:48:30** but **started 09:26:28** — 38 minutes queued on the self-hosted group. GitHub resolves the workflow file at queue time, and the `kimi-k3` caller fix merged at 09:09:25, in between. So this run legitimately used the old `k3`.

Worth knowing generally: with queue times like that, a run can execute a workflow version ~40 minutes stale. Runs created after 09:09:25 do use `kimi-k3` — and still 400, which is why this diagnostic matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)