### PR TITLE
fix: speak the openai dialect to the LiteLLM proxy, and expose provider_type

### DIFF
--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -57,9 +57,12 @@ inputs:
     required: false
     default: "1048576"
   provider_type:
-    description: "Provider dialect for the Kimi CLI. Maps to KIMI_MODEL_PROVIDER_TYPE."
+    description: "Wire dialect the CLI speaks. One of kimi, anthropic, openai, openai_responses, google-genai, vertexai. MUST match what base_url actually serves: `kimi` targets the Kimi Code platform at api.kimi.com/coding/v1 and a LiteLLM proxy rejects it with a bare 400; `openai` speaks plain /v1/chat/completions, which is what the proxy serves. Defaults to `openai` to pair with the default base_url. Maps to KIMI_MODEL_PROVIDER_TYPE."
     required: false
-    default: "kimi"
+    # Paired with the default base_url (the LiteLLM proxy). Verified: a plain
+    # OpenAI-style chat/completions request for kimi-k3 succeeds against that
+    # proxy, while provider_type=kimi returns 400 for the same model and key.
+    default: "openai"
   cli_version:
     description: "Exact @moonshot-ai/kimi-code version to install. Pinned deliberately — the package is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR."
     required: false

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -67,9 +67,24 @@ from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
 | Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash) |
 | `Write` scope | output directory only (allow + catch-all deny) | **unscoped** — see below |
 | Config stripped | `CLAUDE.md`, `AGENTS.md`, `KIMI.md`, `.kimi-code/` | `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.mcp.json`, `.claude/`, `.claude-plugin/` |
-| Applicable inputs | all, incl. `max_context_size`, `cli_version` | all except `max_context_size`, `cli_version` |
+| Applicable inputs | all, incl. `max_context_size`, `cli_version`, `provider_type` | all except `max_context_size`, `cli_version`, `provider_type` |
 | `agent` reported | `ai_review` | `claude_review` |
 | Artifact | `ai-review-summary-*` | `claude-review-summary-*` |
+
+**`provider_type` must match what `base_url` serves.** This is the Kimi engine's
+sharpest trap, because a mismatch produces a bare `400 The request was invalid`
+that names nothing:
+
+| `base_url` | correct `provider_type` |
+|---|---|
+| `https://litellmsa.deriv.ai/v1` (LiteLLM proxy — the default) | `openai` |
+| `https://api.kimi.com/coding/v1` (direct Kimi Code platform) | `kimi` |
+
+The `kimi` dialect is built for the Kimi Code platform and a LiteLLM proxy
+rejects it, even when the model name and key are correct — verified by sending
+the same model and key as a plain `/v1/chat/completions` request, which
+succeeds. **Change these two inputs together, never one alone.** Valid types:
+`kimi`, `anthropic`, `openai`, `openai_responses`, `google-genai`, `vertexai`.
 
 **Model names belong to the endpoint, not the model.** `model` is passed through
 verbatim, so it must be whatever the thing in `base_url` calls it. On the Deriv

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: "0.34.0"
         type: string
+      provider_type:
+        description: "[engine-specific: kimi] Wire dialect the Kimi CLI speaks: kimi, anthropic, openai, openai_responses, google-genai, vertexai. Must match what `base_url` serves — `kimi` targets api.kimi.com/coding/v1 and a LiteLLM proxy rejects it with a bare 400, while `openai` speaks the plain /v1/chat/completions the proxy serves. Change this only alongside `base_url`. Ignored when engine is not `kimi`."
+        required: false
+        default: "openai"
+        type: string
       legacy_markers:
         description: "Newline-separated comment markers from superseded review workflows that this run should ALSO delete, so a PR does not accumulate one stale review comment per workflow it has been through. Empty this only once no open PR org-wide can still carry a pre-migration comment — see AI_PR_REVIEW_README.md."
         required: false
@@ -514,6 +519,7 @@ jobs:
           api_key: ${{ secrets.LLM_API_KEY }}
           max_context_size: ${{ inputs.max_context_size || '1048576' }}
           cli_version: ${{ inputs.cli_version || '0.34.0' }}
+          provider_type: ${{ inputs.provider_type || 'openai' }}
 
       - name: AI review (Anthropic / Claude Code engine)
         id: engine-anthropic


### PR DESCRIPTION
## Root cause — confirmed, not inferred

A plain OpenAI-style request for the **same model, key and endpoint** succeeds:

```bash
curl -sS https://litellmsa.deriv.ai/v1/chat/completions \
  -H "Authorization: Bearer $LLM_API_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}]}'
```

```json
{ "model": "kimi-k3", "provider": "Moonshot AI",
  "choices": [ { "message": { "content": "Hi there! How can I help you today?" } } ],
  "usage": { "total_tokens": 269 } }
```

So the model alias, the key's authorisation and the endpoint were **all fine**. The 400 was the dialect the CLI spoke: `provider_type: kimi` targets the Kimi Code platform at `api.kimi.com/coding/v1`, which is not what a LiteLLM proxy serves.

Valid types are `kimi`, `anthropic`, `openai`, `openai_responses`, `google-genai`, `vertexai`. `openai` is plain `/v1/chat/completions` — exactly what the curl above exercised.

## All three candidates now accounted for

| Candidate | Verdict |
|---|---|
| Model alias `k3` vs `kimi-k3` | real, fixed earlier — necessary but not sufficient |
| `max_context_size` too large | **ruled out** — 29 KB / ~8K tokens against a 1M window |
| Wire format / `provider_type` | **the cause** |

## Changes

- **Default `provider_type` → `openai`**, pairing it with the default `base_url`. This was the same class of bug as `k3` vs `kimi-k3`: two defaults that could not work together, shipped as if they did.
- **Expose `provider_type` as a workflow input.** I deliberately withheld it to keep the public surface small, reasoning that "nobody has ever needed to change it." That was wrong, and it made the one setting that mattered unreachable without editing the shared workflow.
- **Document the pairing** as a table in the README, because a mismatch produces a 400 that names nothing:

| `base_url` | correct `provider_type` |
|---|---|
| `https://litellmsa.deriv.ai/v1` (default) | `openai` |
| `https://api.kimi.com/coding/v1` | `kimi` |

## Test plan

- [x] `yaml-lint` and `actionlint` clean; no empty expressions
- [x] `provider_type` verified wired end to end: workflow input → dispatch → engine input → `KIMI_MODEL_PROVIDER_TYPE`
- [x] Plain `openai`-dialect request to the proxy confirmed working for `kimi-k3`
- [ ] A real review run completing and posting a Kimi review

> Should be merged together with #112 (diagnostics no longer abort). Callers need no change — the new default is correct for the proxy — though deriv-api-v2 will set it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)