### PR TITLE
ci: validate composite actions, and trim the Kimi debug output

### DIFF
--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -225,6 +225,12 @@ runs:
         # was invalid") and points at a log file on a runner that is already gone,
         # so the actual provider request and response body are unrecoverable.
         # Secrets registered with the job are masked in these logs by Actions.
+        # Runs only on failure. Deliberately short: the long troubleshooting essay
+        # this used to print was scaffolding for diagnosing one specific 400 (a
+        # provider_type/base_url mismatch), which is now fixed and documented in
+        # AI_PR_REVIEW_README.md. What stays is what a failing run cannot be
+        # debugged without: the resolved config, the input sizes, and the CLI's own
+        # log if it wrote one.
         dump_kimi_log() {
           # A diagnostic must never be killed by the thing it is diagnosing. The
           # step runs under `bash -e -o pipefail`, so any non-zero command in here
@@ -232,68 +238,31 @@ runs:
           # explicitly straight after, so relaxing this has no other effect.
           set +e +o pipefail
 
-          # Request shape first. A 400 whose body we cannot see is still narrowable
-          # from the sizes: if the packed context approaches the window the proxy
-          # allows for this alias, "context too large" is the likely cause rather
-          # than a bad model name or an unsupported parameter.
-          echo "ℹ️  Resolved provider config: model=$KIMI_MODEL_NAME base_url=$KIMI_MODEL_BASE_URL provider_type=$KIMI_MODEL_PROVIDER_TYPE"
-          echo "ℹ️  max_context_size declared to the CLI: $KIMI_MODEL_MAX_CONTEXT_SIZE tokens"
-          # tr strips the padding BSD wc emits; harmless on the Linux runner but
-          # keeps the numbers readable if this is ever run elsewhere.
+          # tr strips the padding BSD wc emits, harmless on the Linux runner.
           bytes_of() { wc -c < "$1" 2>/dev/null | tr -d '[:space:]' || echo '?'; }
-          echo "ℹ️  Input sizes in bytes: context=$(bytes_of "$CONTEXT_PATH") diff=$(bytes_of "$DIFF_PATH") prompt=$(bytes_of /tmp/review_prompt.txt)"
 
-          # The CLI's error message names $HOME/.kimi-code/logs/kimi-code.log but
-          # does not always create it, so search for whatever it did write instead
-          # of reporting "no log" and giving up — that left the provider response
-          # unrecoverable on the runs this function was added to diagnose.
-          #
-          # `|| true` is load-bearing: the step runs under `bash -e -o pipefail`,
-          # and grep exits 1 when it matches nothing. Without it, pipefail
-          # propagates that failure and set -e kills the script mid-diagnostic —
-          # aborting on exactly the no-log case this branch exists to report, and
-          # swallowing the narrowing hints below. That is what happened on the
-          # first run after this function shipped.
-          KIMI_LOGS=$(find "$HOME" /tmp -maxdepth 5 -type f -name '*.log' 2>/dev/null | grep -i kimi | head -5 || true)
+          echo "ℹ️  config: model=$KIMI_MODEL_NAME base_url=$KIMI_MODEL_BASE_URL provider_type=$KIMI_MODEL_PROVIDER_TYPE max_context_size=$KIMI_MODEL_MAX_CONTEXT_SIZE"
+          echo "ℹ️  input bytes: context=$(bytes_of "$CONTEXT_PATH") diff=$(bytes_of "$DIFF_PATH") prompt=$(bytes_of /tmp/review_prompt.txt)"
 
+          # The CLI names $HOME/.kimi-code/logs/kimi-code.log in its errors but does
+          # not always create it, so search rather than assume.
+          # `|| true` is load-bearing: grep exits 1 on no match, and under pipefail
+          # + set -e that would abort this function mid-dump.
+          KIMI_LOGS=$(find "$HOME" /tmp -maxdepth 5 -type f -name '*.log' 2>/dev/null | grep -i kimi | head -3 || true)
           if [[ -n "$KIMI_LOGS" ]]; then
             while IFS= read -r log; do
-              # tr strips the padding BSD wc emits, so the count reads cleanly off
-              # the Linux runner too.
               lines=$(wc -l < "$log" | tr -d '[:space:]')
-              echo "::group::$log (showing last 200 of $lines lines)"
+              echo "::group::$log (last 200 of $lines lines)"
               tail -n 200 "$log"
               echo "::endgroup::"
-              # Say so explicitly: silent truncation could hide the very error this
-              # dump exists to surface.
-              if [[ "$lines" -gt 200 ]]; then
-                echo "⚠️  $log is $lines lines and only the last 200 are shown."
-                echo "    If the provider request/response is not visible, raise the tail window."
-              fi
+              [[ "$lines" -gt 200 ]] && echo "⚠️  truncated: $log has $lines lines"
             done <<< "$KIMI_LOGS"
           else
-            echo "⚠️  No kimi log found anywhere under \$HOME or /tmp, despite the CLI"
-            echo "    naming \$HOME/.kimi-code/logs/kimi-code.log. The provider response"
-            echo "    body is therefore unavailable from this job."
-            echo "::group::kimi --help (looking for a verbose/debug flag to enable next time)"
-            kimi --help 2>&1 | head -60 || echo "(kimi --help failed)"
-            echo "::endgroup::"
+            echo "ℹ️  no kimi log written; provider response body unavailable"
           fi
 
-          echo "ℹ️  Narrowing a 400 from here:"
-          echo "    1. Model name — must be an alias the endpoint fronts. Kimi-platform"
-          echo "       ids (k3, k3-256k, kimi-for-coding) only resolve at"
-          echo "       api.kimi.com/coding/v1, not on a LiteLLM proxy."
-          echo "    2. max_context_size above the window configured for that alias."
-          echo "    3. A parameter or wire format the proxy rejects (provider_type)."
-          echo "    Run this locally with the key you passed as LLM_API_KEY (that variable"
-          echo "    is deliberately not set in this job, so the lines below are templates):"
-          echo "      curl -s $KIMI_MODEL_BASE_URL/models -H \"Authorization: Bearer \$LLM_API_KEY\" | jq -r '.data[].id'"
-          echo "      curl -sS $KIMI_MODEL_BASE_URL/chat/completions -H \"Authorization: Bearer \$LLM_API_KEY\" \\"
-          echo "        -H 'Content-Type: application/json' \\"
-          echo "        -d '{\"model\":\"$KIMI_MODEL_NAME\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}' | jq ."
-          echo "    The second command is decisive: if it succeeds, the model and key are"
-          echo "    fine and the problem is in what the CLI sends, not what it targets."
+          echo "ℹ️  Troubleshooting: AI_PR_REVIEW_README.md — a 400 is usually a"
+          echo "    model/provider_type/base_url mismatch, and those must agree."
         }
 
         # No GitHub token in this step's env and no Bash tool in the config: the

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -21,7 +21,6 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
-      - '.github/workflows/lint-actions.yml'
   workflow_dispatch:
 
 permissions:
@@ -30,6 +29,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
@@ -39,7 +39,11 @@ jobs:
           # (mostly unquoted $GITHUB_OUTPUT redirects) that would drown the real
           # errors. This catches Actions-level mistakes — bad expressions, unknown
           # contexts, invalid keys — which is what actually breaks a run.
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          #
+          # Both the download script and the actionlint version are pinned, so a
+          # new actionlint release with new rules cannot turn this gate red
+          # without a change in this repo. Bump both deliberately.
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/3795ba2f6cb243eeca54c9d22e5c531cb9dcfb4a/scripts/download-actionlint.bash) 1.7.12
           ./actionlint -shellcheck= -color
 
       - name: Lint composite actions
@@ -48,6 +52,13 @@ jobs:
           # so this file cannot trip check 1 on itself.
           OPEN=$(printf '\x24\x7b\x7b')
           fail=0
+
+          # PyYAML ships preinstalled on ubuntu-latest. Fail loudly if that ever
+          # changes, rather than reporting every action as "invalid YAML".
+          if ! python3 -c 'import yaml' 2>/dev/null; then
+            echo "::error::PyYAML is not available on the runner — the YAML validity check cannot run"
+            exit 1
+          fi
 
           shopt -s nullglob
           actions=(.github/actions/*/action.yml .github/actions/*/action.yaml)
@@ -59,10 +70,11 @@ jobs:
           for f in "${actions[@]}"; do
             echo "── $f"
 
-            # 0. Valid YAML at all.
-            if ! npx --yes yaml-lint "$f" >/dev/null 2>&1; then
+            # 0. Valid YAML at all. PyYAML is preinstalled on the runner, so this
+            #    needs no network and no third-party code fetched at run time.
+            if ! err=$(python3 -c 'import sys, yaml; yaml.safe_load(open(sys.argv[1]))' "$f" 2>&1); then
               echo "::error file=$f::invalid YAML"
-              npx --yes yaml-lint "$f" 2>&1 | tail -5
+              echo "$err" | tail -5
               fail=1
             fi
 
@@ -86,7 +98,7 @@ jobs:
             # 3. secrets context: unavailable inside composite actions. It does not
             #    error, it resolves to empty, so a credential silently goes missing.
             if grep -nE '\bsecrets\.[A-Za-z_]' "$f"; then
-              echo "::error file=$f::composite actions cannot read the secrets context — pass the value in as an input"
+              echo "::error file=$f::composite actions cannot read the secrets context — pass the value in as an input. This check also matches comments — reword them rather than referencing secrets.NAME."
               fail=1
             fi
           done

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,98 @@
+name: Lint Actions
+
+# Validates this repo's own workflows and composite actions.
+#
+# It exists because composite actions had NO validation at all, and three bugs
+# shipped to master through that gap in a single day:
+#   1. An empty Actions expression pair inside a `run:` block — valid YAML, so
+#      yaml-lint passed, but it fails manifest loading and every consumer job
+#      died at "Set up job" before running a step.
+#   2. `timeout-minutes:` on a step inside a composite action — silently
+#      unsupported, so a 60-minute cap was quietly dropped.
+#   3. A `secrets.` reference inside a composite action — unavailable there, and
+#      it resolves to empty rather than erroring.
+#
+# actionlint does NOT cover any of this: it only parses `.github/workflows/`, and
+# handing it an `action.yml` makes it complain the file has no `jobs:` section.
+# Hence the explicit checks below.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/workflows/lint-actions.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Lint workflows with actionlint
+        run: |
+          # shellcheck is disabled: the repo has ~250 pre-existing style findings
+          # (mostly unquoted $GITHUB_OUTPUT redirects) that would drown the real
+          # errors. This catches Actions-level mistakes — bad expressions, unknown
+          # contexts, invalid keys — which is what actually breaks a run.
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -shellcheck= -color
+
+      - name: Lint composite actions
+        run: |
+          # The opening delimiter is assembled from bytes rather than written out,
+          # so this file cannot trip check 1 on itself.
+          OPEN=$(printf '\x24\x7b\x7b')
+          fail=0
+
+          shopt -s nullglob
+          actions=(.github/actions/*/action.yml .github/actions/*/action.yaml)
+          if [[ ${#actions[@]} -eq 0 ]]; then
+            echo "::error::no composite actions found — has the layout changed?"
+            exit 1
+          fi
+
+          for f in "${actions[@]}"; do
+            echo "── $f"
+
+            # 0. Valid YAML at all.
+            if ! npx --yes yaml-lint "$f" >/dev/null 2>&1; then
+              echo "::error file=$f::invalid YAML"
+              npx --yes yaml-lint "$f" 2>&1 | tail -5
+              fail=1
+            fi
+
+            # 1. Empty expression pair. Actions scans the WHOLE run: string for
+            #    expressions, including lines bash treats as comments, and an empty
+            #    one fails manifest validation before any step executes. The error
+            #    it reports points at the start of the block scalar, not the
+            #    offending line, so it reads like an indentation problem.
+            if grep -nE '\$\{\{[[:space:]]*\}\}' "$f"; then
+              echo "::error file=$f::empty Actions expression pair — fails manifest loading. Reword so an empty '$OPEN }}' is not written literally, even inside a comment."
+              fail=1
+            fi
+
+            # 2. timeout-minutes on an inner step: not supported in composite
+            #    actions. Put it on the calling step in the workflow instead.
+            if grep -nE '^[[:space:]]*timeout-minutes:' "$f"; then
+              echo "::error file=$f::timeout-minutes is not supported on steps inside a composite action — move it to the calling step"
+              fail=1
+            fi
+
+            # 3. secrets context: unavailable inside composite actions. It does not
+            #    error, it resolves to empty, so a credential silently goes missing.
+            if grep -nE '\bsecrets\.[A-Za-z_]' "$f"; then
+              echo "::error file=$f::composite actions cannot read the secrets context — pass the value in as an input"
+              fail=1
+            fi
+          done
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo "::error::composite action lint failed — see annotations above"
+            exit 1
+          fi
+          echo "✅ ${#actions[@]} composite action(s) passed"


### PR DESCRIPTION
Two independent commits, either revertable alone.

## 1. Validate composite actions — nothing did

`.github/actions/**/action.yml` had **no validation whatsoever**, and three bugs reached master through that gap in a single day:

| # | Bug | Why it slipped through |
|---|---|---|
| 1 | Empty Actions expression pair inside a `run:` block | Valid YAML, so `yaml-lint` passed. Manifest loading fails, so every consumer job died at **Set up job** before executing a step. |
| 2 | `timeout-minutes:` on an inner step | Silently unsupported in composite actions — a 60-minute cap was quietly dropped. |
| 3 | `secrets.` reference inside a composite action | Unavailable there; resolves to **empty** rather than erroring, so a credential goes missing without a signal. |

**`actionlint` covers none of this.** It only parses `.github/workflows/` — hand it an `action.yml` and it reports a missing `jobs:` section. That is why these were invisible.

The new job adds explicit checks for those three plus YAML validity, and runs `actionlint` over the workflows with `-shellcheck=` (the repo has ~250 pre-existing style findings, mostly unquoted `$GITHUB_OUTPUT` redirects, which would drown real errors).

Verified against fixtures reproducing each bug:

```
1. empty expression pair           exit=1  ::error file=...::empty Actions expression pair
2. timeout-minutes inner step      exit=1  ::error file=...::timeout-minutes is not supported
3. secrets context                 exit=1  ::error file=...::composite actions cannot read secrets
4. clean action (must pass)        exit=0
```

And against the real tree: **all 14 existing actions pass unchanged**, so this goes green on merge rather than creating a backlog.

One detail: the check assembles the expression delimiter from bytes (`printf '\x24\x7b\x7b'`) so this workflow cannot trip check 1 on itself — which it otherwise would, being a file that has to talk about empty expression pairs.

## 2. Trim the Kimi failure diagnostics

The failure dump had grown to **70 lines producing ~25 lines of output**: a three-item troubleshooting list, two curl templates, and a 60-line `kimi --help` dump. That was scaffolding for diagnosing one specific 400 — the `provider_type`/`base_url` mismatch — which is now fixed and documented in `AI_PR_REVIEW_README.md`.

Now **33 lines, four lines of output**, keeping only what a failing run genuinely needs:

```
ℹ️  config: model=kimi-k3 base_url=https://litellmsa.deriv.ai/v1 provider_type=openai max_context_size=1048576
ℹ️  input bytes: context=20074 diff=7826 prompt=1168
ℹ️  no kimi log written; provider response body unavailable
ℹ️  Troubleshooting: AI_PR_REVIEW_README.md — a 400 is usually a
    model/provider_type/base_url mismatch, and those must agree.
```

The `set +e +o pipefail` guard and the `|| true` on the log search **stay** — those were bug fixes (the dump used to abort mid-run), not verbosity. Verified the no-log path still runs to completion under `bash -e -o pipefail`.

## Test plan

- [x] Gate catches all three historical bug classes; clean action passes
- [x] All 14 existing composite actions pass → green on merge
- [x] `actionlint -shellcheck=` clean across the repo
- [x] Trimmed diagnostic verified on the no-log path under the runner's shell flags
- [ ] Confirm the gate runs and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)