### PR TITLE
fix: strip PR-supplied agent config in claude-pr-review, not just CLAUDE.md

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -261,8 +261,38 @@ jobs:
 
           echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
 
-      - name: Remove CLAUDE.md to prevent project config leaking into review
-        run: rm -f CLAUDE.md
+      - name: Strip PR-supplied agent config
+        # Security boundary, not hygiene — and deliberately wider than the
+        # `rm -f CLAUDE.md` this replaces. Everything below is PR-controlled and
+        # reaches the agent as trusted configuration, none of it gated by the
+        # --allowedTools allowlist further down:
+        #   .claude/settings.json  can declare HOOKS, which execute arbitrary
+        #                          commands in this job — the job holds a
+        #                          write-scoped GITHUB_TOKEN and the API key
+        #   .claude/rules/*.md     load on demand when a matching file is read
+        #   .mcp.json              declares MCP servers (arbitrary local commands)
+        #   .claude-plugin/        plugin manifest
+        #   CLAUDE.md, CLAUDE.local.md, AGENTS.md   instruction files
+        #
+        # Recursive, not root-only: Claude Code discovers CLAUDE.md and
+        # CLAUDE.local.md in subdirectories and loads them when it reads files
+        # there, and this review's prompt tells it to traverse into dependencies.
+        # A nested packages/foo/CLAUDE.md therefore reached the model even with the
+        # root file deleted. AGENTS.md is stripped defensively — Claude Code does
+        # not read it natively, but a CLAUDE.md can @import it.
+        #
+        # .git is pruned so the sweep cannot corrupt the checkout.
+        run: |
+          find . -name .git -prune -o -type f \
+            \( -name 'CLAUDE.md' -o -name 'CLAUDE.local.md' -o -name 'AGENTS.md' -o -name '.mcp.json' \) \
+            -print0 | xargs -0 -r rm -f
+          find . -name .git -prune -o -type d \
+            \( -name '.claude' -o -name '.claude-plugin' \) \
+            -print0 | xargs -0 -r rm -rf
+          # Persistent runner: clear cross-run agent state too.
+          rm -rf "$HOME/.claude"
+          rm -f "$HOME/.claude.json"
+          echo "✅ Stripped PR-supplied agent config (recursive)"
 
       - name: Claude Code PR Review
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa


### PR DESCRIPTION
## Why this one matters

`claude-pr-review.yml` is **live in 14 repos** and strips only the root `CLAUDE.md`. Everything below is PR-controlled, reaches the agent as trusted configuration, and is **not** gated by the `--allowedTools` allowlist:

| Path | What a PR can do with it |
|---|---|
| `.claude/settings.json` | declare **hooks — arbitrary command execution** in a job holding a write-scoped `GITHUB_TOKEN` and the API key |
| `.claude/rules/*.md` | inject instructions, loaded on demand when a matching file is read |
| `.mcp.json` | declare MCP servers (arbitrary local commands) |
| `.claude-plugin/` | plugin manifest |
| `CLAUDE.local.md`, `AGENTS.md` | further instruction files |

The hooks case is the sharp one: it does not need the model's cooperation at all.

## Also: root-only was not enough

Claude Code discovers `CLAUDE.md`/`CLAUDE.local.md` in **subdirectories** and loads them when it reads files there — and this review's prompt explicitly tells the model to traverse into dependencies. So a nested `packages/foo/CLAUDE.md` reached it even with the root file deleted. The sweep is now recursive, with `.git` pruned so it cannot corrupt the checkout.

## Verified on a fixture

```
before:                                   after:
  ./.claude/settings.json  (hooks)          ./.git/objects/CLAUDE.md
  ./.mcp.json                               ./src/app.ts
  ./CLAUDE.md
  ./packages/foo/CLAUDE.md
  ./packages/foo/.claude/rules/evil.md
  ./.git/objects/CLAUDE.md
  ./src/app.ts
```

Injection vectors gone; `.git` internals and source untouched.

## Why now rather than at migration

This brings the workflow to parity with `ai_review_engine_anthropic`, which shipped with the wider list. The original plan was to retire this file behind a shim — but that has no date, and this is the workflow running on 14 repos *today*. Not worth leaving open for weeks.

## Blast radius and behaviour change

Affects all 14 consumers on merge. It strips strictly more than before, so the one visible change is that a monorepo's **nested** `CLAUDE.md` files no longer reach the reviewer as context. That is the intent of the step (its old name was "prevent project config leaking into review"), and changes to those files are still visible in the diff — but worth knowing if any repo was relying on package-level conventions reaching the reviewer.

## Still open here

The agent keeps `Bash(gh pr diff:*)` / `Bash(gh pr view:*)`. Closing that needs the diff pre-fetch the new workflow has, which is a larger change — deliberately out of scope so this stays a small, revertable security fix.

## Test plan

- [x] `yaml-lint` and `actionlint -shellcheck=` clean
- [x] Fixture: hooks/`.mcp.json`/nested configs removed, `.git` and source spared
- [ ] One consumer PR reviewed after merge, confirming reviews still post normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)