### PR TITLE
ci: dogfood the Kimi review on this repo's own PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,77 @@
+name: AI PR Review (Kimi K3)
+
+# Dogfoods this repo's own review workflow on this repo's own PRs.
+#
+# This is the highest-value place to run it: the engine code lives here, so a
+# regression in ai-pr-review.yml or ai_review_engine_* shows up on our own PRs
+# before it reaches the 14 consumer repos.
+#
+# Runs ALONGSIDE claude.yml on purpose, so Kimi K3 and Claude review the same PRs
+# and can be compared. Every PR gets two review comments, told apart by header:
+#   "## 🤖 AI PR Review Complete"     <- this workflow (Kimi K3)
+#   "## 🤖 Claude PR Review Complete" <- claude.yml (claude-sonnet-5)
+#
+# TWO SELF-REFERENCE CAVEATS, both worth knowing before trusting a green run here:
+#
+#   1. The trigger is pull_request_target, so GitHub runs the workflow file from
+#      the BASE branch. A PR that edits this caller is therefore reviewed by
+#      master's copy, not its own.
+#   2. The reusable workflow and the engine actions are pulled at @master. A PR
+#      that changes ai-pr-review.yml or an engine action is reviewed by the
+#      version already on master, not the version in the PR.
+#
+#   So this dogfoods what is MERGED, not what is proposed. To exercise an engine
+#   change before merge, temporarily point the refs in ai-pr-review.yml at
+#   @<branch> and revert before merging.
+#
+# Docs: .github/workflows/AI_PR_REVIEW_README.md
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  ai-review:
+    # Absolute path at @master rather than a local `./` path, matching claude.yml
+    # and docsync-ai.yml. It also keeps this caller identical in shape to the
+    # consumer repos', so dogfooding exercises the same resolution path they use.
+    uses: deriv-com/shared-actions/.github/workflows/ai-pr-review.yml@master
+
+    # Exactly what the shared workflow declares. `actions: write` and
+    # `id-token: write` were dropped from it (nothing calls the Actions API, no
+    # step mints an OIDC token), so they are not needed here either — unlike
+    # claude.yml, which still grants both for the older workflow.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    with:
+      # All three pinned rather than inherited, so a change to a shared default
+      # cannot silently alter what this repo runs — which matters more here than
+      # anywhere, since this is where those defaults are edited.
+      engine: kimi
+      # LiteLLM proxy alias for K3. The Kimi-platform id `k3` resolves only at
+      # api.kimi.com/coding/v1 and the proxy answers it with a bare 400.
+      model: kimi-k3
+      # Wire dialect. Must match what base_url serves: the proxy serves plain
+      # /v1/chat/completions, which is `openai`. `kimi` targets the Kimi Code
+      # platform and the proxy rejects it, even with a correct model and key.
+      provider_type: openai
+
+      # REQUIRED while claude.yml also runs. The shared workflow defaults this to
+      # "Claude PR Review Complete" so a repo migrating OFF claude-pr-review.yml
+      # cleans up its leftovers; left at that default here, this run would delete
+      # the Claude review it is being compared against on every push. Emptying it
+      # leaves Claude's comments alone — each workflow reaps only its own.
+      # Restore the default when claude.yml is removed.
+      legacy_markers: ""
+
+    secrets:
+      # LiteLLM virtual key, authorised for `kimi-k3` on litellmsa.deriv.ai.
+      # NOTE: this secret does not exist in this repo yet — it must be added
+      # (repo- or org-level) or the run fails at the engine step.
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      # Optional. Unset here, so review events go to the job summary only.
+      AGENT_METRICS_API_URL: ${{ secrets.AGENT_METRICS_API_URL }}
+      AGENT_METRICS_API_KEY: ${{ secrets.AGENT_METRICS_API_KEY }}


### PR DESCRIPTION
## Summary

Enables the Kimi review on **shared-actions' own PRs**, alongside the existing `claude.yml`.

This is the highest-value place to run it — the engine code lives here, so a regression in `ai-pr-review.yml` or `ai_review_engine_*` shows up on our own PRs **before** it reaches the 14 consumer repos. It's the dogfood step from the original migration plan, just arriving after the engine was made to work rather than before.

Named `ai-review.yml` because `ai-pr-review.yml` is the reusable workflow itself, mirroring the existing `claude.yml` / `claude-pr-review.yml` split.

## ⚠️ Requires a secret this repo does not have

| Secret | Present in shared-actions? |
|---|---|
| **`LLM_API_KEY`** | ❌ **no — must be added** |
| `ANTHROPIC_API_KEY` | ✅ (used by `claude.yml`) |
| `AGENT_METRICS_API_*` | ❌ absent — events go to the job summary only |

```bash
gh secret set LLM_API_KEY --repo deriv-com/shared-actions
```

Since this is now the **second** repo needing the same key, an org secret would avoid a third copy:

```bash
gh secret set LLM_API_KEY --org deriv-com --visibility selected --repos shared-actions,deriv-api-v2
```

Without it the run fails at the engine step with an auth error — loudly, not silently.

## Two self-reference caveats

Both documented in the file, because a green run here means less than it appears:

1. **`pull_request_target` runs the base branch's workflow**, so a PR editing this caller is reviewed by master's copy — including this PR, which therefore gets no Kimi review.
2. **The reusable workflow and engine actions resolve at `@master`**, so a PR changing an engine is reviewed by the version already on master, not the proposed one.

**So this dogfoods what is merged, not what is proposed.** To exercise an engine change pre-merge you still have to point the refs at `@<branch>` temporarily and revert before merging.

## Config

`engine`, `model` and `provider_type` are all pinned rather than inherited. That matters more here than in a consumer repo: this is the repo where those defaults get edited, and an accidental change shouldn't silently alter what we run.

`legacy_markers: ""` keeps the side-by-side honest — otherwise this run would delete the Claude review it's being compared against on every push.

## Test plan

- [x] `yaml-lint` and `actionlint -shellcheck=` clean
- [x] No filename collision with the reusable workflow
- [x] Every input and secret passed is declared by master's `ai-pr-review.yml`
- [x] Caller grants exactly the permissions the reusable workflow declares
- [ ] Add `LLM_API_KEY`, then confirm the **next** PR after this merges gets both reviews and neither deletes the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)