### PR TITLE
fix: harden the AI PR review flow — review integrity, security, cleanup

### DIFF
--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -135,20 +135,21 @@ runs:
         anthropic_api_key: ${{ inputs.api_key }}
         # The action needs a token for its own actor/permission checks.
         #
-        # Be precise about what this engine does and does not guarantee, because
-        # it is weaker than the Kimi engine's. Per the action's docs at the pinned
-        # SHA: "The base GitHub tools are always included" — so --allowedTools ADDS
-        # to a base set rather than replacing it, and some GitHub tool surface is
-        # not removable. What IS established: Claude "cannot execute Bash commands
-        # unless explicitly allowed", so omitting Bash genuinely removes shell
-        # access; and it "cannot post multiple comments" / "cannot submit formal
-        # PR reviews" by design.
+        # What the model can actually reach here — verified against the action's
+        # SOURCE at the pinned SHA, not its docs (the docs' "base GitHub tools
+        # are always included" describes tag mode): passing `prompt:` puts the
+        # action in AGENT mode, and in agent mode src/mcp/install-mcp-server.ts
+        # mounts the github_comment MCP server only when --allowedTools requests
+        # mcp__github_comment__* tools, the file-ops server only with commit
+        # signing, and the inline-comment server only when requested. Ours asks
+        # for "Read,Write", so NO GitHub MCP server is mounted at all — the
+        # model holds no comment tool, same guarantee as the Kimi engine.
         #
-        # So "exactly one review comment" rests on three things here, not one:
-        #   1. track_progress is off, so there is no tracking comment to update
-        #   2. the prompt explicitly forbids commenting (step 5 below)
-        #   3. the caller deletes any marker-matching comment before posting
-        # Unlike the Kimi engine, it is NOT enforced by the tool surface alone.
+        # Because that rests on source behavior at one SHA rather than a
+        # documented contract, --disallowedTools below re-denies those servers
+        # (plus Bash/WebFetch/WebSearch) as a belt — so a future SHA bump that
+        # changes agent-mode defaults fails safe instead of silently widening
+        # the surface. The caller's delete-before-post remains the final layer.
         github_token: ${{ github.token }}
         # track_progress is deliberately NOT set. It forces tag mode, which makes
         # the action post and update its own tracking comment on the PR — that
@@ -156,30 +157,25 @@ runs:
         # cleanup step only reaps comments carrying the review marker, so tracking
         # comments would accumulate on every PR forever.
         show_full_output: true
+        # The step-by-step review procedure lives in the caller-built context
+        # file (its "Review Procedure" section), NOT here — it is engine-neutral,
+        # and duplicating it per engine let the copies drift. This prompt only
+        # bootstraps the model into that file.
         prompt: |
           REPO: ${{ inputs.repository }}
           PR NUMBER: ${{ inputs.pr_number }}
 
-          Follow these steps:
+          Read ${{ inputs.review_context_path }} and follow it exactly. It contains
+          the full review instructions, PR context, previous review (if any),
+          acknowledged suggestions to skip, and the required output format — plus a
+          "Review Procedure" section telling you what else to read, including the
+          pre-fetched PR diff at ${{ inputs.pr_diff_path }}, and requiring you to
+          write your complete review to ${{ inputs.output_path }} with the Write
+          tool. You have no shell tool; everything you need is on disk.
 
-          1. Read ${{ inputs.review_context_path }} — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
-
-          2. Read ${{ inputs.pr_diff_path }} — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
-
-          3. For each changed file, use Read to open the full file — not just the diff hunk.
-             Full file context is required to understand the complete impact of each change.
-
-          4. For each changed file, identify and Read its dependencies:
-             - Imported modules, utilities, or shared helpers referenced in the changed code
-             - Type definitions, interfaces, or enums used by the changed code
-             - Parent components or callers if the changed file exports something modified
-             - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
-
-          5. After reading ALL files and dependencies, compile your complete review.
-             Write the ENTIRE review to ${{ inputs.output_path }} using the Write tool.
-             Do NOT post, create or update any PR or issue comment, and do not use
-             any GitHub tool to publish your review. Writing the file is the whole
-             job — the caller posts it as a single comment.
+          Do NOT post, create or update any PR or issue comment, and do not use
+          any GitHub tool to publish your review. Writing the file is the whole
+          job — the caller posts it as a single comment.
         # Bash is dropped entirely: the diff is pre-fetched, so the previous
         # `Bash(gh pr diff:*)` grant bought nothing and rested on the CLI's
         # command-pattern matching being argv-aware — under a naive prefix match,
@@ -195,9 +191,16 @@ runs:
         # and writes nothing, tightening this needs a real run to verify, not a
         # guess — tracked in the PR test plan. Until then the asymmetry is real
         # and documented rather than papered over.
+        #
+        # --disallowedTools is the belt for the agent-mode analysis on
+        # github_token above: server-level MCP names deny every tool of those
+        # servers, and disallowing a tool that is not mounted is a no-op — this
+        # only matters if a future SHA bump mounts them again. Disallowed takes
+        # precedence over allowed in the CLI, so it cannot mask Read/Write.
         claude_args: |
           --model ${{ inputs.model }}
           --allowedTools "Read,Write"
+          --disallowedTools "Bash,WebFetch,WebSearch,mcp__github_comment,mcp__github_inline_comment,mcp__github_file_ops,mcp__github"
 
     - name: Verify review output
       id: verify

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -196,28 +196,21 @@ runs:
         # whole run: string for expressions, including text bash treats as a
         # comment, and an empty one fails manifest validation before any step
         # runs — which is exactly how this file got broken once already.
+        # The step-by-step review procedure lives in the caller-built context
+        # file (its "Review Procedure" section), NOT here — it is engine-neutral,
+        # and duplicating it per engine let the copies drift. This prompt only
+        # bootstraps the model into that file.
         cat > /tmp/review_prompt.txt <<'EOF'
         REPO: ${{ inputs.repository }}
         PR NUMBER: ${{ inputs.pr_number }}
 
-        Follow these steps:
-
-        1. Read ${{ inputs.review_context_path }} — it contains full review instructions, PR context, previous review (if any), acknowledged suggestions to skip, and the required output format.
-
-        2. Read ${{ inputs.pr_diff_path }} — it contains the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk.
-
-        3. For each changed file, use Read to open the full file — not just the diff hunk.
-           Full file context is required to understand the complete impact of each change.
-
-        4. For each changed file, identify and Read its dependencies:
-           - Imported modules, utilities, or shared helpers referenced in the changed code
-           - Type definitions, interfaces, or enums used by the changed code
-           - Parent components or callers if the changed file exports something modified
-           - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
-
-        5. After reading ALL files and dependencies, compile your complete review.
-           Write the ENTIRE review to ${{ inputs.output_path }} using the Write tool.
-           The caller posts that file as a single PR comment.
+        Read ${{ inputs.review_context_path }} and follow it exactly. It contains
+        the full review instructions, PR context, previous review (if any),
+        acknowledged suggestions to skip, and the required output format — plus a
+        "Review Procedure" section telling you what else to read, including the
+        pre-fetched PR diff at ${{ inputs.pr_diff_path }}, and requiring you to
+        write your complete review to ${{ inputs.output_path }} with the Write
+        tool. You have no shell tool; everything you need is on disk.
         EOF
 
         # Dumps the CLI's own log on failure. Without this the step reports only

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -16,10 +16,11 @@ engine is pluggable: pick `kimi` or `anthropic` with one input.
 
 - 🤖 Full-context review — reads changed files whole, plus their imports, types, callers and tests
 - 🔄 Follow-up mode — on re-push, feeds the previous review plus an incremental diff so fixed items are not re-reported
-- 🧹 Exactly one review comment per PR, ever — old ones are captured and deleted first
+- 🧹 Exactly one review comment per PR, ever — captured at the start, deleted seconds before the replacement posts, so a failed or cancelled run never leaves the PR without its review
 - 🔌 Pluggable engine (`kimi` | `anthropic`), each a composite action with its own CLI and sandbox
 - 🔒 The model gets **no shell tool** and no GitHub token — it cannot comment, and PR-supplied agent config is stripped before it starts
-- ✅ Respects `Click2Fix - Acknowledge` comments — acknowledged suggestions are never raised again
+- 🛡️ The post step refuses to publish a review containing the LLM API key (comment bodies are not covered by Actions secret masking), and truncates bodies over GitHub's 65,536-character comment limit instead of failing
+- ✅ Respects `Click2Fix - Acknowledge` comments from the posting bot or accounts with repo standing — acknowledged suggestions are never raised again
 - 📊 Emits events to the OneAboveAll metrics dashboard, and always to the job summary
 
 ## Usage
@@ -63,8 +64,8 @@ from `claude-pr-review.yml` that omits it would silently switch LLM vendor.
 | Runtime | `@moonshot-ai/kimi-code` CLI (npm, pinned) | `anthropics/claude-code-action` (pinned by SHA) |
 | Default model | `kimi-k3` | `claude-sonnet-5` |
 | `base_url` sent | proxy origin **+ `/v1`** | proxy origin, **`/v1` stripped** |
-| Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` **+ the action's base GitHub tools** |
-| Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash) |
+| Tools granted | `Read`, `Write`, `Grep`, `Glob` | `Read`, `Write` (agent mode mounts **no** GitHub MCP servers — see below) |
+| Shell | none (absent from `enabled` **and** denied by rule) | none (`--allowedTools` omits Bash, `--disallowedTools` re-denies it) |
 | `Write` scope | output directory only (allow + catch-all deny) | **unscoped** — see below |
 | Config stripped | `CLAUDE.md`, `AGENTS.md`, `KIMI.md`, `.kimi-code/` | `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.mcp.json`, `.claude/`, `.claude-plugin/` |
 | Applicable inputs | all, incl. `max_context_size`, `cli_version`, `provider_type` | all except `max_context_size`, `cli_version`, `provider_type` |
@@ -107,29 +108,38 @@ receive one. Each engine normalises the value it is given, so the same
 not "fix" this by giving the dispatch per-engine defaults — that would make one
 input value mean two different things.
 
-**The two engines are not equally sandboxed.** Be precise about this rather than
+**How each engine's sandbox actually holds.** Be precise about this rather than
 assuming parity:
 
 - **Kimi** — the tool surface *is* the guarantee. Bash is absent from `enabled`
   and denied by rule; `Write` is confined to the output directory by an allow rule
   plus a catch-all deny; no GitHub token reaches the step at all. The agent
-  cannot comment because it has no means to.
-- **Anthropic** — weaker, in two ways. `--allowedTools` **adds to** a base set
-  rather than replacing it (the action's docs: *"The base GitHub tools are always
-  included"*), so some GitHub tool surface is not removable and the action does
-  hold a token for its own actor checks. And `Write` is unscoped, because
+  cannot comment because it has no means to. Its `Read` is unscoped, though —
+  which is why the caller's post step scans the review for the API key before
+  publishing (see below).
+- **Anthropic** — stronger than the action's docs suggest. The docs' *"base
+  GitHub tools are always included"* describes **tag mode**; passing `prompt:`
+  selects **agent mode**, and the action's source at the pinned SHA mounts the
+  `github_comment` MCP server only when `--allowedTools` requests its tools,
+  file-ops only with commit signing, inline comments only when requested. Ours
+  requests `Read,Write`, so **no GitHub MCP server is mounted at all** — the
+  model holds no comment tool, matching the Kimi guarantee. Because that rests
+  on source behavior at one SHA, the engine also passes `--disallowedTools`
+  denying those servers plus Bash/WebFetch/WebSearch, so a future SHA bump that
+  changes agent-mode defaults fails safe. `Write` is unscoped, because
   path-scoped patterns are only documented for `Bash`, and the workflow this
   replaced recorded that a scoped `Write(/path)` made the tool unavailable
-  entirely. Shell access *is* definitively gone — the docs confirm Bash is off
-  unless explicitly allowed.
+  entirely. The action does hold a token for its own actor checks.
 
-  So on this engine "exactly one review comment" rests on three things: no
-  tracking comment (`track_progress` is off), an explicit prompt instruction not
-  to comment, and the caller deleting marker-matching comments before posting.
+Tightening the Anthropic `Write` grant (or scoping the Kimi `Read`) needs a
+verification run, since a pattern the CLI reads as "tool unavailable" means the
+engine reviews and writes nothing. Do not "fix" either blind.
 
-Tightening the Anthropic `Write` grant needs a verification run, since an
-unavailable `Write` means the engine reviews and writes nothing. Do not
-"fix" it blind.
+**Post-step guards, engine-neutral:** whatever the engine, the caller refuses to
+post a review containing the `LLM_API_KEY` value (Actions masks secrets in logs,
+**not** in comment bodies — and the model's input is attacker-influenced PR
+content), and truncates bodies over GitHub's 65,536-character comment limit
+(full text preserved in the job log) instead of failing the run.
 
 **A model swap is config; an engine swap is a rewrite.** Any model the LiteLLM
 proxy fronts can be reached by setting `model` (and `max_context_size` on Kimi).
@@ -138,17 +148,26 @@ CLI has its own config format, sandbox model, tool names and entrypoint.
 
 ## Inputs
 
-| Input | Description | Required | Default |
+| Input | Description | Required | Default (resolved when empty) |
 |-------|-------------|----------|---------|
 | `engine` | `kimi` or `anthropic` | ❌ | `kimi` |
-| `model` | Model ID; resolved per engine when empty | ❌ | `""` |
+| `model` | Model ID; resolved per engine when empty | ❌ | per engine |
 | `base_url` | LLM API endpoint; `/v1` added or stripped per engine | ❌ | `https://litellmsa.deriv.ai/v1` |
 | `max_context_size` | **[kimi]** Context window in tokens. Must match the model, or the CLI over-packs and the API rejects the request | ❌ | `1048576` |
 | `cli_version` | **[kimi]** Exact `@moonshot-ai/kimi-code` version | ❌ | `0.34.0` |
+| `provider_type` | **[kimi]** Wire dialect; must match what `base_url` serves | ❌ | `openai` |
 | `legacy_markers` | Newline-separated markers from superseded workflows to also delete | ❌ | `Claude PR Review Complete` |
-| `prompt_gist_url` | Review prompt template | ❌ | DerivFE gist |
+| `prompt_gist_url` | Review prompt template | ❌ | DerivFE gist, **pinned to a revision** |
 
-Inputs marked **[kimi]** are ignored by other engines.
+Inputs marked **[kimi]** are ignored by other engines. Every input except
+`engine` and `legacy_markers` declares `default: ""` and is resolved to the
+values above inside the `Resolve and validate engine` step — so each default
+exists in exactly one place, and that step is where you bump any of them.
+
+The gist default is pinned to a specific revision on purpose: the bare `raw/`
+URL is mutable, and a gist edit would rewrite the review agent's instructions
+for every consumer live, with no PR and no audit trail. To roll out a new
+prompt, edit the gist, then bump the revision hash in the resolve step via PR.
 
 `cli_version` is pinned deliberately: `@moonshot-ai/kimi-code` is pre-1.0 and
 ships minor releases weekly, so `latest` would pull both breaking changes and
@@ -202,8 +221,12 @@ composite actions consistently, not just here — is a reasonable follow-up.
 
 ## Comment markers and cleanup
 
-Each run deletes prior review comments before posting, so a PR carries exactly
-one. Detection uses a canonical hidden marker, `<!-- deriv-pr-review -->`, which
+Each run deletes prior review comments **immediately before posting** the
+replacement, so a PR carries exactly one — and a run that fails or is cancelled
+mid-review leaves the old comment untouched. (Deletion used to happen at the
+start of the run, which meant every engine failure or cancel-in-progress in the
+up-to-an-hour gap destroyed the previous review and its reviewed-commit SHA.)
+Detection uses a canonical hidden marker, `<!-- deriv-pr-review -->`, which
 the **post step appends** — it is not something the model is asked to emit.
 Earlier versions depended on the model reproducing a visible header, which meant
 one reworded header left a duplicate comment on the PR forever.
@@ -321,18 +344,27 @@ CLI reads.
 
 ## How It Works
 
+0. **Bot skip** — the job does not run at all for `*[bot]` actors (they cannot
+   pass the gate, and a red run on every dependabot PR reads like a regression).
 1. **Access gate** — actor must be a `deriv-com` member or a repo collaborator.
-2. **Resolve engine** — validate `engine`, resolve per-engine defaults.
-3. **Checkout** PR head (depth 20, for the incremental diff).
-4. **Fetch prompt** template from the gist; inject the Click2Fix URL.
-5. **Capture and delete** prior review comments (canonical + legacy markers,
-   paginated), keeping the newest as `PREVIOUS_REVIEW` and extracting its
-   `reviewed-commit` SHA.
-6. **Collect acknowledged suggestions** from `Click2Fix - Acknowledge` comments.
+2. **Resolve engine** — validate `engine`, resolve per-engine and engine-neutral
+   defaults (the single place every default value lives).
+3. **Checkout** the event's `head.sha` — not the branch, which could have moved
+   past what the gate validated — at depth 20, for the incremental diff.
+4. **Fetch prompt** template from the pinned gist revision; inject the Click2Fix URL.
+5. **Capture** the newest prior review comment (canonical + legacy markers,
+   paginated) as `PREVIOUS_REVIEW` and extract its `reviewed-commit` SHA.
+   Capture only — deletion waits until step 10.
+6. **Collect acknowledged suggestions** from `Click2Fix - Acknowledge` comments
+   posted by the bot or by accounts with repo standing (`author_association`),
+   so a drive-by comment cannot suppress findings.
 7. **Build `/tmp/review_context.md`** — instructions, previous review,
-   noise-filtered incremental diff, acknowledged items, PR metadata, output format.
-8. **Pre-fetch the diff** to `/tmp/pr_diff.txt` with the trusted token, so the
-   engine needs no shell.
+   noise-filtered incremental diff, acknowledged items, PR metadata, review
+   procedure, output format.
+8. **Pre-fetch the diff** to `/tmp/pr_diff.txt` with the trusted token (so the
+   engine needs no shell), noise-filtered like the incremental diff.
 9. **Dispatch to the engine** — it writes `/tmp/ai_review_output.txt`.
-10. **Post** exactly one comment, appending the detection markers.
+10. **Post**: scan the review for the API key (refuse if found), truncate over
+    GitHub's comment limit, **then** delete prior review comments and post the
+    replacement seconds later, appending the detection markers.
 11. **Emit metrics** to the dashboard and the job summary; upload the payload.

--- a/.github/workflows/AI_PR_REVIEW_README.md
+++ b/.github/workflows/AI_PR_REVIEW_README.md
@@ -16,7 +16,7 @@ engine is pluggable: pick `kimi` or `anthropic` with one input.
 
 - 🤖 Full-context review — reads changed files whole, plus their imports, types, callers and tests
 - 🔄 Follow-up mode — on re-push, feeds the previous review plus an incremental diff so fixed items are not re-reported
-- 🧹 Exactly one review comment per PR, ever — captured at the start, deleted seconds before the replacement posts, so a failed or cancelled run never leaves the PR without its review
+- 🧹 Exactly one review comment per PR — the old one is captured at the start and deleted only after its replacement is live, so a failed or cancelled run never leaves the PR without its review
 - 🔌 Pluggable engine (`kimi` | `anthropic`), each a composite action with its own CLI and sandbox
 - 🔒 The model gets **no shell tool** and no GitHub token — it cannot comment, and PR-supplied agent config is stripped before it starts
 - 🛡️ The post step refuses to publish a review containing the LLM API key (comment bodies are not covered by Actions secret masking), and truncates bodies over GitHub's 65,536-character comment limit instead of failing
@@ -221,9 +221,11 @@ composite actions consistently, not just here — is a reasonable follow-up.
 
 ## Comment markers and cleanup
 
-Each run deletes prior review comments **immediately before posting** the
-replacement, so a PR carries exactly one — and a run that fails or is cancelled
-mid-review leaves the old comment untouched. (Deletion used to happen at the
+Each run deletes prior review comments **only after the replacement has
+posted** (the reap-list is captured just before posting, so the new comment
+cannot match its own filter), so a PR carries exactly one — and a run that
+fails at any point leaves the old comment untouched. The worst case is a
+transient duplicate, which the next run reaps. (Deletion used to happen at the
 start of the run, which meant every engine failure or cancel-in-progress in the
 up-to-an-hour gap destroyed the previous review and its reviewed-commit SHA.)
 Detection uses a canonical hidden marker, `<!-- deriv-pr-review -->`, which
@@ -362,9 +364,10 @@ CLI reads.
    noise-filtered incremental diff, acknowledged items, PR metadata, review
    procedure, output format.
 8. **Pre-fetch the diff** to `/tmp/pr_diff.txt` with the trusted token (so the
-   engine needs no shell), noise-filtered like the incremental diff.
+   engine needs no shell), filtered for build noise only — lockfiles and
+   generated output, never test or doc files, which the review must see.
 9. **Dispatch to the engine** — it writes `/tmp/ai_review_output.txt`.
 10. **Post**: scan the review for the API key (refuse if found), truncate over
-    GitHub's comment limit, **then** delete prior review comments and post the
-    replacement seconds later, appending the detection markers.
+    GitHub's comment limit, append the detection markers, post the replacement,
+    **then** delete the prior review comments captured just before posting.
 11. **Emit metrics** to the dashboard and the job summary; upload the payload.

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -122,10 +122,16 @@ jobs:
       REVIEW_CONTEXT_FILE: /tmp/review_context.md
       PR_DIFF_FILE: /tmp/pr_diff.txt
 
-      # Files whose diffs carry no review signal, filtered from BOTH the main
-      # pre-fetched diff and the incremental diff. Lives here so the two steps
-      # that filter cannot drift apart.
-      NOISE_PATTERN: 'package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.snap|\.min\.js|\.min\.css|dist/|build/|\.generated\.|__generated__|/vendor/|\.pb\.go|_test\.snap|\.spec\.(tsx?|jsx?)|/__tests__/|\.scss$|\.md$'
+      # Files whose diffs carry no review signal ANYWHERE — lockfiles and
+      # generated/minified/vendored output — filtered from BOTH the main
+      # pre-fetched diff and the incremental diff. Deliberately NARROW: test
+      # files, styles and docs are NOT here, because the main diff is what the
+      # initial review sees and test coverage is a stated review criterion —
+      # filtering *.spec.* from it silently defeated that. The incremental
+      # diff appends those extras where it is built, since there the filter
+      # only scopes "what changed since last review", not what gets reviewed
+      # at all.
+      NOISE_PATTERN: 'package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.snap|\.min\.js|\.min\.css|dist/|build/|\.generated\.|__generated__|/vendor/|\.pb\.go|_test\.snap'
 
       # Comment markers identifying a review comment as ours. Canonical marker
       # first — appended deterministically by the post step, so detection never
@@ -286,8 +292,8 @@ jobs:
         # (an engine 400, a timeout, a cancel-in-progress from a new push) left
         # the PR with NO review comment and destroyed the reviewed-commit SHA —
         # so the next run silently degraded to an initial review. The post step
-        # now deletes immediately before posting, shrinking that window from up
-        # to an hour to about a second.
+        # now deletes only AFTER the replacement is live, closing that window
+        # entirely.
         id: previous-review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -431,13 +437,17 @@ jobs:
           echo "event_type=$EVENT_TYPE" >> $GITHUB_OUTPUT
 
           # Pre-compute incremental diff (changes since last review) for follow-up
-          # mode. NOISE_PATTERN comes from job env — one definition shared with
-          # the main diff fetch below.
+          # mode. The shared NOISE_PATTERN (job env) is extended with test, style
+          # and doc files HERE ONLY: in this diff the filter merely scopes "what
+          # changed since the last review", while in the main diff (which uses
+          # NOISE_PATTERN alone) it would remove those files from review
+          # entirely.
+          INCREMENTAL_NOISE_PATTERN="${NOISE_PATTERN}"'|\.spec\.(tsx?|jsx?)|/__tests__/|\.scss$|\.md$'
           echo "" > /tmp/incremental_diff.txt
           if [[ "$HAS_PREVIOUS" == "true" && -n "$LAST_REVIEWED_SHA" ]]; then
             echo "📋 Generating incremental diff since last reviewed commit: $LAST_REVIEWED_SHA"
             if git cat-file -e "$LAST_REVIEWED_SHA" 2>/dev/null; then
-              git diff "$LAST_REVIEWED_SHA"..HEAD | awk -v noise="$NOISE_PATTERN" '
+              git diff "$LAST_REVIEWED_SHA"..HEAD | awk -v noise="$INCREMENTAL_NOISE_PATTERN" '
                 /^diff --git / { in_noise = ($0 ~ noise); if (!in_noise) print; next }
                 !in_noise { print }
               ' > /tmp/incremental_diff.txt
@@ -665,8 +675,8 @@ jobs:
           # input (the diff, the PR description). If an injection ever talks the
           # model into echoing its credentials (e.g. read from /proc/*/environ),
           # this is the last point where posting them publicly can be stopped.
-          # Everything before the delete below is deliberately fail-CLOSED: on
-          # any failure in this step's checks, the previous review is untouched.
+          # Everything up to the post below is deliberately fail-CLOSED: on any
+          # failure in this step's checks, the previous review is untouched.
           if [[ -n "$LLM_API_KEY" ]] && grep -qF -- "$LLM_API_KEY" "$REVIEW_OUTPUT_FILE"; then
             echo "❌ Review output contains the LLM API key — refusing to post. Rotate the key and inspect the run."
             exit 1
@@ -704,21 +714,29 @@ jobs:
             printf '<!-- deriv-pr-review -->\n'
           } >> "$REVIEW_OUTPUT_FILE"
 
-          # Delete the previous review only NOW, seconds before its replacement
-          # posts. This used to happen in the capture step, an hour earlier —
-          # any engine failure or a cancel-in-progress in between left the PR
-          # with no review at all and destroyed the reviewed-commit SHA. Fresh
-          # fetch (comments may have changed during the engine run), same filter
-          # file the capture step used, delete ALL matches including legacy.
+          # Reap-list for prior reviews, captured BEFORE posting — the new
+          # comment carries the markers too, so a fetch-after-post would match
+          # (and delete) the comment it just created. Fresh fetch, since
+          # comments may have changed during the engine run; same filter file
+          # the capture step used, ALL matches including legacy.
+          #
+          # Post FIRST, delete after. Deletion used to happen in the capture
+          # step, an hour earlier — any failure in between left the PR with no
+          # review at all and destroyed the reviewed-commit SHA. Deleting even
+          # a second before posting kept a sliver of that: a failed post after
+          # a successful delete is the same loss in miniature. This ordering
+          # trades it for the harmless inverse — a transient duplicate that the
+          # next run reaps, since its reap-list is built the same way.
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
             | jq -s 'add // []' > /tmp/comments_at_post.json
           jq -f /tmp/review_marker_filter.jq /tmp/comments_at_post.json \
-            | jq -r '.[].id' \
-            | xargs -r -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE
+            | jq -r '.[].id' > /tmp/reap_ids.txt
 
           echo "📬 Posting review ($(wc -c < "$REVIEW_OUTPUT_FILE") bytes)..."
           gh pr comment "$PR_NUMBER" --body-file "$REVIEW_OUTPUT_FILE"
-          echo "✅ Review posted"
+
+          xargs -r -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE < /tmp/reap_ids.txt
+          echo "✅ Review posted, previous review(s) reaped"
 
       - name: Emit review event to metrics dashboard
         if: always()

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -36,24 +36,24 @@ on:
         default: ""
         type: string
       base_url:
-        description: "Base URL of the LLM API endpoint. Engine-neutral: a trailing /v1 is added or removed as each engine requires, so the same value works across engines. Use https://api.kimi.com/coding/v1 for direct Kimi Code platform access."
+        description: "Base URL of the LLM API endpoint. Engine-neutral: a trailing /v1 is added or removed as each engine requires, so the same value works across engines. Use https://api.kimi.com/coding/v1 for direct Kimi Code platform access. Empty resolves to https://litellmsa.deriv.ai/v1 (the LiteLLM proxy) — the real default lives in the 'Resolve and validate engine' step so it exists in exactly one place."
         required: false
-        default: "https://litellmsa.deriv.ai/v1"
+        default: ""
         type: string
       max_context_size:
-        description: "[engine-specific: kimi] Maximum context window in tokens. Must not exceed the window the endpoint actually allows for the selected model, or the CLI over-packs context and the request is rejected. K3 is 1048576; the 256k variants are 262144. If a request fails with a 400 after the model name is confirmed correct, try lowering this. Ignored when engine is not `kimi`."
+        description: "[engine-specific: kimi] Maximum context window in tokens. Must not exceed the window the endpoint actually allows for the selected model, or the CLI over-packs context and the request is rejected. K3 is 1048576; the 256k variants are 262144. If a request fails with a 400 after the model name is confirmed correct, try lowering this. Empty resolves to 1048576. Ignored when engine is not `kimi`."
         required: false
-        default: "1048576"
+        default: ""
         type: string
       cli_version:
-        description: "[engine-specific: kimi] Exact @moonshot-ai/kimi-code version to install. Pinned deliberately — the package is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Bump via PR. Ignored when engine is not `kimi`."
+        description: "[engine-specific: kimi] Exact @moonshot-ai/kimi-code version to install. Pinned deliberately — the package is pre-1.0 and ships minor releases weekly, so `latest` risks both breaking changes and unreviewed code in a privileged job. Empty resolves to the pinned version in the 'Resolve and validate engine' step; bump it there via PR. Ignored when engine is not `kimi`."
         required: false
-        default: "0.34.0"
+        default: ""
         type: string
       provider_type:
-        description: "[engine-specific: kimi] Wire dialect the Kimi CLI speaks: kimi, anthropic, openai, openai_responses, google-genai, vertexai. Must match what `base_url` serves — `kimi` targets api.kimi.com/coding/v1 and a LiteLLM proxy rejects it with a bare 400, while `openai` speaks the plain /v1/chat/completions the proxy serves. Change this only alongside `base_url`. Ignored when engine is not `kimi`."
+        description: "[engine-specific: kimi] Wire dialect the Kimi CLI speaks: kimi, anthropic, openai, openai_responses, google-genai, vertexai. Must match what `base_url` serves — `kimi` targets api.kimi.com/coding/v1 and a LiteLLM proxy rejects it with a bare 400, while `openai` speaks the plain /v1/chat/completions the proxy serves. Change this only alongside `base_url`. Empty resolves to `openai`. Ignored when engine is not `kimi`."
         required: false
-        default: "openai"
+        default: ""
         type: string
       legacy_markers:
         description: "Newline-separated comment markers from superseded review workflows that this run should ALSO delete, so a PR does not accumulate one stale review comment per workflow it has been through. Empty this only once no open PR org-wide can still carry a pre-migration comment — see AI_PR_REVIEW_README.md."
@@ -61,9 +61,9 @@ on:
         default: "Claude PR Review Complete"
         type: string
       prompt_gist_url:
-        description: "URL to fetch prompt template from"
+        description: "URL to fetch the prompt template from. Empty resolves to the DerivFE gist PINNED TO A REVISION — the unpinned raw/ URL would let a gist edit silently rewrite the review agent's instructions for every consumer, live, with no PR. To roll out a new prompt, update the revision hash in the 'Resolve and validate engine' step via PR."
         required: false
-        default: "https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/claude-review-format.md"
+        default: ""
         type: string
     secrets:
       LLM_API_KEY:
@@ -80,7 +80,12 @@ jobs:
   ai-review:
     runs-on:
       group: github_claude_code_reviewer
-    if: github.event.pull_request.draft == false
+    # Bot actors are skipped, not failed: dependabot and friends are not org
+    # members, so they cannot pass the access gate below — without this guard
+    # every bot PR produces a red run that reads like a workflow regression.
+    # Skipping also avoids spending LLM tokens on lockfile-bump PRs. A human
+    # actor failing the gate still fails red, which is the correct signal.
+    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')
 
     permissions:
       # `actions:` is deliberately absent. Permissions can only be reduced, never
@@ -110,10 +115,27 @@ jobs:
       cancel-in-progress: true
 
     env:
-      # Single source of truth for the review file both the engine and the post
-      # step touch. REVIEW_MODEL is NOT here — it depends on `engine`, so the
-      # "Resolve and validate engine" step writes it to $GITHUB_ENV.
+      # Single source of truth for the three files the steps and the engine
+      # hand to each other. REVIEW_MODEL is NOT here — it depends on `engine`,
+      # so the "Resolve and validate engine" step writes it to $GITHUB_ENV.
       REVIEW_OUTPUT_FILE: /tmp/ai_review_output.txt
+      REVIEW_CONTEXT_FILE: /tmp/review_context.md
+      PR_DIFF_FILE: /tmp/pr_diff.txt
+
+      # Files whose diffs carry no review signal, filtered from BOTH the main
+      # pre-fetched diff and the incremental diff. Lives here so the two steps
+      # that filter cannot drift apart.
+      NOISE_PATTERN: 'package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.snap|\.min\.js|\.min\.css|dist/|build/|\.generated\.|__generated__|/vendor/|\.pb\.go|_test\.snap|\.spec\.(tsx?|jsx?)|/__tests__/|\.scss$|\.md$'
+
+      # Comment markers identifying a review comment as ours. Canonical marker
+      # first — appended deterministically by the post step, so detection never
+      # depends on the model reproducing a visible header. Legacy markers let a
+      # run also reap comments left by workflows this one supersedes. Job-level
+      # because both the capture step and the post step (which deletes) need it.
+      REVIEW_MARKERS: |
+        <!-- deriv-pr-review -->
+        AI PR Review Complete
+        ${{ inputs.legacy_markers }}
 
     steps:
       - name: Security Check - Validate User Access
@@ -138,6 +160,11 @@ jobs:
         env:
           ENGINE_INPUT: ${{ inputs.engine }}
           MODEL_INPUT: ${{ inputs.model }}
+          BASE_URL_INPUT: ${{ inputs.base_url }}
+          MAX_CONTEXT_INPUT: ${{ inputs.max_context_size }}
+          CLI_VERSION_INPUT: ${{ inputs.cli_version }}
+          PROVIDER_TYPE_INPUT: ${{ inputs.provider_type }}
+          PROMPT_GIST_URL_INPUT: ${{ inputs.prompt_gist_url }}
         run: |
           ENGINE="${ENGINE_INPUT:-kimi}"
 
@@ -179,9 +206,32 @@ jobs:
 
           MODEL="${MODEL_INPUT:-$DEFAULT_MODEL}"
 
-          echo "engine=$ENGINE" >> "$GITHUB_OUTPUT"
-          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
-          echo "artifact_prefix=$ARTIFACT_PREFIX" >> "$GITHUB_OUTPUT"
+          # Engine-neutral defaults, resolved HERE and nowhere else. The input
+          # declarations default to "" and every consumer of these values reads
+          # the step outputs, so each default value exists in exactly one place
+          # — previously they were duplicated between the input declaration and
+          # `||` fallbacks at each use site, which is how defaults drift apart.
+          #
+          # The gist URL is pinned to a revision: the bare raw/ URL is mutable,
+          # and whoever edits the gist would rewrite the review agent's
+          # instructions for every consumer with no PR and no audit trail. To
+          # ship a new prompt, edit the gist, then bump this hash via PR.
+          BASE_URL="${BASE_URL_INPUT:-https://litellmsa.deriv.ai/v1}"
+          MAX_CONTEXT="${MAX_CONTEXT_INPUT:-1048576}"
+          CLI_VERSION="${CLI_VERSION_INPUT:-0.34.0}"
+          PROVIDER_TYPE="${PROVIDER_TYPE_INPUT:-openai}"
+          PROMPT_GIST_URL="${PROMPT_GIST_URL_INPUT:-https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/2d5131aa058801e99fe77f69db124bf583f7d3ea/claude-review-format.md}"
+
+          {
+            echo "engine=$ENGINE"
+            echo "model=$MODEL"
+            echo "artifact_prefix=$ARTIFACT_PREFIX"
+            echo "base_url=$BASE_URL"
+            echo "max_context_size=$MAX_CONTEXT"
+            echo "cli_version=$CLI_VERSION"
+            echo "provider_type=$PROVIDER_TYPE"
+            echo "prompt_gist_url=$PROMPT_GIST_URL"
+          } >> "$GITHUB_OUTPUT"
 
           # Consumed by later `run:` scripts (review header, metrics payload,
           # step summary) rather than by `if:`, so $GITHUB_ENV is fine here.
@@ -202,14 +252,20 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # head.sha, NOT head.ref. This is pull_request_target: the access gate
+          # above validated the actor of THIS event, and checking out the branch
+          # name instead would fetch whatever the branch points at by now —
+          # including commits pushed after the gate ran, which nothing validated.
+          # Pinning to the event's SHA also makes the reviewed-commit marker mean
+          # what it says. Concurrency narrows that race; this closes it.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 20
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch prompt template from Gist
         id: fetch-prompt
         env:
-          PROMPT_GIST_URL: ${{ inputs.prompt_gist_url || 'https://gist.githubusercontent.com/DerivFE/048e18e3d2e8c0cddf4c3f434835d57f/raw/claude-review-format.md' }}
+          PROMPT_GIST_URL: ${{ steps.engine.outputs.prompt_gist_url }}
         run: |
           # -f matters: without it curl exits 0 on 4xx/5xx and returns the error
           # page body, which is non-empty — so the emptiness check below would
@@ -224,53 +280,58 @@ jobs:
           printf '%s' "$PROMPT_TEMPLATE" > /tmp/prompt_template.txt
           echo "✅ Prompt template saved ($(wc -c < /tmp/prompt_template.txt) bytes)"
 
-      - name: Capture and cleanup previous review
+      - name: Capture previous review
+        # Capture ONLY. Deletion used to happen here too, which meant any failure
+        # or cancellation in the ~60 minutes between this step and the post step
+        # (an engine 400, a timeout, a cancel-in-progress from a new push) left
+        # the PR with NO review comment and destroyed the reviewed-commit SHA —
+        # so the next run silently degraded to an initial review. The post step
+        # now deletes immediately before posting, shrinking that window from up
+        # to an hour to about a second.
         id: previous-review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Canonical marker first — appended deterministically by the post step,
-          # so detection no longer depends on the model reproducing a visible
-          # header. Legacy markers let this run also reap comments left by
-          # workflows it supersedes; without them a PR open across a migration
-          # keeps one orphaned review comment per workflow, forever.
-          REVIEW_MARKERS: |
-            <!-- deriv-pr-review -->
-            AI PR Review Complete
-            ${{ inputs.legacy_markers }}
         run: |
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          # --paginate: the default page size is 30, so the previous single-call
-          # version silently missed review comments on busy PRs and left
-          # duplicates behind. Fetch once, filter locally, reuse for the delete.
-          # `jq -s add` merges the per-page arrays --paginate concatenates (do not
-          # use `--jq` with a whole-array filter — it applies per page).
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            | jq -s 'add' > /tmp/all_comments.json
-
+          # Shared with the post step's delete, so capture and delete can never
+          # match different comment sets. REVIEW_MARKERS is job-level env for the
+          # same reason ($ENV.REVIEW_MARKERS reads it at jq run time).
+          #
           # Substring matching, not regex, so marker content needs no escaping.
           #
           # The marker MUST be captured with `. as $marker` before piping into
           # `$body`. Writing the condition as `$body | contains(.)` looks right but
           # rebinds `.` to $body inside the pipe, making it `$body contains $body`
           # — always true. That silently matched EVERY github-actions[bot] comment
-          # on the PR, so the delete loop below would reap unrelated bot comments
+          # on the PR, so the delete would reap unrelated bot comments
           # (DocSync, QA checklist, ...) instead of just prior reviews.
-          FILTER='
-            ($ENV.REVIEW_MARKERS | split("\n") | map(select(length > 0))) as $markers
-            | map(select(
-                .user.login == "github-actions[bot]"
-                and (.body as $body | any($markers[]; . as $marker | $body | contains($marker)))
-              ))
-            | sort_by(.created_at)
-          '
+          cat > /tmp/review_marker_filter.jq <<'JQ'
+          ($ENV.REVIEW_MARKERS | split("\n") | map(select(length > 0))) as $markers
+          | map(select(
+              .user.login == "github-actions[bot]"
+              and (.body as $body | any($markers[]; . as $marker | $body | contains($marker)))
+            ))
+          | sort_by(.created_at)
+          JQ
+
+          # --paginate: the default page size is 30, so the previous single-call
+          # version silently missed review comments on busy PRs and left
+          # duplicates behind. Fetch once, filter locally; the acknowledged-
+          # suggestions step reuses this file rather than re-fetching.
+          # `jq -s 'add // []'` merges the per-page arrays --paginate concatenates
+          # (do not use `--jq` with a whole-array filter — it applies per page);
+          # `// []` guards the zero-output case, where `add` yields null and the
+          # filter's map() would error.
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            | jq -s 'add // []' > /tmp/all_comments.json
 
           # `last` — newest match only. A PR that crossed a migration legitimately
           # holds two matching comments; concatenating them produced a MULTI-LINE
           # last_reviewed_sha, which corrupts $GITHUB_OUTPUT.
-          jq -r "$FILTER | last | .body // empty" /tmp/all_comments.json \
-            > /tmp/previous_review.txt
+          jq -f /tmp/review_marker_filter.jq /tmp/all_comments.json \
+            | jq -r 'last | .body // empty' > /tmp/previous_review.txt
 
           if [ -s /tmp/previous_review.txt ]; then
             echo "has_previous=true" >> "$GITHUB_OUTPUT"
@@ -285,44 +346,54 @@ jobs:
             echo "ℹ️ No previous review found"
           fi
 
-          # Delete ALL matches, legacy included — not just the newest one.
-          jq -r "$FILTER | .[].id" /tmp/all_comments.json \
-            | xargs -r -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE
-
       - name: Fetch acknowledged suggestions
         id: acknowledged
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REPO="${{ github.repository }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
           echo "🔍 Scanning for Click2Fix - Acknowledge comments..."
 
-          # Find comments containing "Click2Fix - Acknowledge" and extract bullet points
-          ACKNOWLEDGE_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | contains("Click2Fix - Acknowledge")) | .body' 2>/dev/null || echo "")
+          # Reads /tmp/all_comments.json from the capture step instead of calling
+          # the API again — which also fixes two bugs the old separate call had:
+          # it was unpaginated (an acknowledge comment past the first 30 comments
+          # was silently ignored), and it swallowed API errors as "no comment".
+          #
+          # The author filter is the important part. Acknowledged items are fed
+          # to the model as "must NOT appear in your review", so an unrestricted
+          # match is a finding-suppression channel: ANY account could comment
+          # "Click2Fix - Acknowledge" + "- concerns about the auth change" and
+          # the reviewer would be instructed to stay silent about it. Restricted
+          # to the posting bot and to accounts GitHub attests have repo standing
+          # (author_association is computed server-side and cannot be spoofed).
+          jq -r '
+            map(select(
+              (.body | contains("Click2Fix - Acknowledge"))
+              and (
+                .user.login == "github-actions[bot]"
+                or (.author_association | IN("OWNER", "MEMBER", "COLLABORATOR"))
+              )
+            ))
+            | .[].body
+          ' /tmp/all_comments.json > /tmp/acknowledge_comments.txt
 
-          if [ -n "$ACKNOWLEDGE_COMMENT" ]; then
-            echo "✅ Found acknowledge comment"
+          if [ -s /tmp/acknowledge_comments.txt ]; then
+            echo "✅ Found acknowledge comment(s)"
 
-            # Extract bullet points (lines starting with - or *) using printf for safer handling
-            ACKNOWLEDGED_ITEMS=$(printf '%s\n' "$ACKNOWLEDGE_COMMENT" | grep -E '^\s*[-*]\s+' | sed 's/^\s*[-*]\s*//' || echo "")
+            # Extract bullet points (lines starting with - or *)
+            ACKNOWLEDGED_ITEMS=$(grep -E '^\s*[-*]\s+' /tmp/acknowledge_comments.txt | sed 's/^\s*[-*]\s*//' || true)
 
             if [ -n "$ACKNOWLEDGED_ITEMS" ]; then
               printf '%s\n' "$ACKNOWLEDGED_ITEMS" > /tmp/acknowledged_items.txt
-              echo "has_acknowledged=true" >> $GITHUB_OUTPUT
+              echo "has_acknowledged=true" >> "$GITHUB_OUTPUT"
               echo "📋 Acknowledged items:"
               printf '%s\n' "$ACKNOWLEDGED_ITEMS"
             else
-              echo "" > /tmp/acknowledged_items.txt
-              echo "has_acknowledged=false" >> $GITHUB_OUTPUT
+              : > /tmp/acknowledged_items.txt
+              echo "has_acknowledged=false" >> "$GITHUB_OUTPUT"
               echo "ℹ️ No bullet items found in acknowledge comment"
             fi
           else
-            echo "" > /tmp/acknowledged_items.txt
-            echo "has_acknowledged=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ No Click2Fix - Acknowledge comment found"
+            : > /tmp/acknowledged_items.txt
+            echo "has_acknowledged=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No Click2Fix - Acknowledge comment found (from an authorized author)"
           fi
 
       - name: Build review context
@@ -359,10 +430,9 @@ jobs:
           [[ "$HAS_PREVIOUS" == "true" ]] && EVENT_TYPE="followup_review" || EVENT_TYPE="initial_review"
           echo "event_type=$EVENT_TYPE" >> $GITHUB_OUTPUT
 
-          # Noise pattern for incremental diff filtering — same set as before
-          NOISE_PATTERN='package-lock\.json|yarn\.lock|pnpm-lock\.yaml|\.snap|\.min\.js|\.min\.css|dist/|build/|\.generated\.|__generated__|/vendor/|\.pb\.go|_test\.snap|\.spec\.(tsx?|jsx?)|/__tests__/|\.scss$|\.md$'
-
-          # Pre-compute incremental diff (changes since last review) for follow-up mode
+          # Pre-compute incremental diff (changes since last review) for follow-up
+          # mode. NOISE_PATTERN comes from job env — one definition shared with
+          # the main diff fetch below.
           echo "" > /tmp/incremental_diff.txt
           if [[ "$HAS_PREVIOUS" == "true" && -n "$LAST_REVIEWED_SHA" ]]; then
             echo "📋 Generating incremental diff since last reviewed commit: $LAST_REVIEWED_SHA"
@@ -449,6 +519,23 @@ jobs:
               echo ""
             fi
 
+            # Review procedure — engine-neutral, so it lives here rather than
+            # being duplicated (and drifting) in every engine's prompt. Engines
+            # point the model at this file; this section takes over from there.
+            echo "## Review Procedure"
+            echo ""
+            echo "Work through these steps in order:"
+            echo ""
+            echo "1. Read $PR_DIFF_FILE — the full diff for this PR (changed files and hunks), already fetched for you. You have no shell tool; everything you need is on disk."
+            echo "2. For each changed file, use Read to open the full file — not just the diff hunk. Full file context is required to understand the complete impact of each change."
+            echo "3. For each changed file, identify and Read its dependencies:"
+            echo "   - Imported modules, utilities, or shared helpers referenced in the changed code"
+            echo "   - Type definitions, interfaces, or enums used by the changed code"
+            echo "   - Parent components or callers if the changed file exports something modified"
+            echo "   - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps"
+            echo "4. After reading ALL files and dependencies, compile your complete review and write the ENTIRE review to $REVIEW_OUTPUT_FILE using the Write tool. Do not post, create, or update any PR or issue comment — writing that file is the whole job; the caller posts it as a single comment."
+            echo ""
+
             # Output format — the header is for human readers only. Follow-up
             # detection no longer depends on the model reproducing it: the post
             # step appends the canonical <!-- deriv-pr-review --> marker and the
@@ -462,9 +549,9 @@ jobs:
             echo ""
             printf '**Model:** \`%s\` | **Review Type:** %s\n' "$REVIEW_MODEL" "$REVIEW_TYPE"
 
-          } > /tmp/review_context.md
+          } > "$REVIEW_CONTEXT_FILE"
 
-          echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
+          echo "📋 Review context built ($(wc -c < "$REVIEW_CONTEXT_FILE") bytes)"
 
       - name: Fetch PR diff for review
         # Fetched here with the trusted token rather than by the review agent, so the
@@ -477,9 +564,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          gh pr diff "$PR_NUMBER" > /tmp/pr_diff.txt
-          [[ -s /tmp/pr_diff.txt ]] || { echo "❌ PR diff is empty"; exit 1; }
-          echo "✅ PR diff fetched ($(wc -c < /tmp/pr_diff.txt) bytes)"
+          gh pr diff "$PR_NUMBER" > /tmp/pr_diff_raw.txt
+          [[ -s /tmp/pr_diff_raw.txt ]] || { echo "❌ PR diff is empty"; exit 1; }
+
+          # Same noise filter the incremental diff gets (NOISE_PATTERN is job
+          # env): lockfile and generated-file churn carries no review signal but
+          # eats context window — and the PRs with the most lockfile churn are
+          # exactly the ones most likely to blow the model's context budget.
+          awk -v noise="$NOISE_PATTERN" '
+            /^diff --git / { in_noise = ($0 ~ noise); if (!in_noise) print; next }
+            !in_noise { print }
+          ' /tmp/pr_diff_raw.txt > "$PR_DIFF_FILE"
+
+          # A PR whose every file matches the noise pattern (a lockfile-only
+          # bump, a docs-only change) still deserves a review of what it does
+          # contain — fall back to the unfiltered diff rather than handing the
+          # engine an empty file, which it treats as a hard error.
+          if [[ ! -s "$PR_DIFF_FILE" ]]; then
+            echo "ℹ️ Every changed file matched the noise filter — using the unfiltered diff"
+            cp /tmp/pr_diff_raw.txt "$PR_DIFF_FILE"
+          fi
+
+          echo "✅ PR diff fetched ($(wc -c < /tmp/pr_diff_raw.txt) bytes raw, $(wc -c < "$PR_DIFF_FILE") after noise filter)"
 
       # ======================== ENGINE DISPATCH ============================
       # Exactly one step below runs. `uses:` accepts no expressions, so engine
@@ -511,15 +617,15 @@ jobs:
         with:
           repository: ${{ github.repository }}
           pr_number: ${{ github.event.pull_request.number }}
-          review_context_path: /tmp/review_context.md
-          pr_diff_path: /tmp/pr_diff.txt
+          review_context_path: ${{ env.REVIEW_CONTEXT_FILE }}
+          pr_diff_path: ${{ env.PR_DIFF_FILE }}
           output_path: ${{ env.REVIEW_OUTPUT_FILE }}
           model: ${{ steps.engine.outputs.model }}
-          base_url: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
+          base_url: ${{ steps.engine.outputs.base_url }}
           api_key: ${{ secrets.LLM_API_KEY }}
-          max_context_size: ${{ inputs.max_context_size || '1048576' }}
-          cli_version: ${{ inputs.cli_version || '0.34.0' }}
-          provider_type: ${{ inputs.provider_type || 'openai' }}
+          max_context_size: ${{ steps.engine.outputs.max_context_size }}
+          cli_version: ${{ steps.engine.outputs.cli_version }}
+          provider_type: ${{ steps.engine.outputs.provider_type }}
 
       - name: AI review (Anthropic / Claude Code engine)
         id: engine-anthropic
@@ -529,11 +635,11 @@ jobs:
         with:
           repository: ${{ github.repository }}
           pr_number: ${{ github.event.pull_request.number }}
-          review_context_path: /tmp/review_context.md
-          pr_diff_path: /tmp/pr_diff.txt
+          review_context_path: ${{ env.REVIEW_CONTEXT_FILE }}
+          pr_diff_path: ${{ env.PR_DIFF_FILE }}
           output_path: ${{ env.REVIEW_OUTPUT_FILE }}
           model: ${{ steps.engine.outputs.model }}
-          base_url: ${{ inputs.base_url || 'https://litellmsa.deriv.ai/v1' }}
+          base_url: ${{ steps.engine.outputs.base_url }}
           api_key: ${{ secrets.LLM_API_KEY }}
 
       # ====================== END ENGINE DISPATCH ==========================
@@ -542,23 +648,73 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_SHA: ${{ steps.build-context.outputs.current_sha }}
+          # For the exfiltration guard below only — never interpolated into a
+          # command line, and grep reads it from the environment.
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
 
           if [ ! -s "$REVIEW_OUTPUT_FILE" ]; then
             echo "❌ Review file $REVIEW_OUTPUT_FILE missing or empty — the '$REVIEW_ENGINE' engine ran but produced no output"
             exit 1
           fi
 
+          # Exfiltration guard. Actions masks secrets in LOGS, not in comment
+          # bodies — and the model's output is derived from attacker-influenced
+          # input (the diff, the PR description). If an injection ever talks the
+          # model into echoing its credentials (e.g. read from /proc/*/environ),
+          # this is the last point where posting them publicly can be stopped.
+          # Everything before the delete below is deliberately fail-CLOSED: on
+          # any failure in this step's checks, the previous review is untouched.
+          if [[ -n "$LLM_API_KEY" ]] && grep -qF -- "$LLM_API_KEY" "$REVIEW_OUTPUT_FILE"; then
+            echo "❌ Review output contains the LLM API key — refusing to post. Rotate the key and inspect the run."
+            exit 1
+          fi
+
+          # GitHub caps issue comments at 65536 characters; a 422 here used to
+          # fail the run. Truncate with headroom for the markers appended below,
+          # preserving the full text in the step log first. head -c can split a
+          # multibyte character at the cut; iconv -c drops the partial sequence
+          # so the body stays valid UTF-8 (GitHub rejects invalid encodings).
+          MAX_BODY=64000
+          SIZE=$(wc -c < "$REVIEW_OUTPUT_FILE")
+          if [ "$SIZE" -gt "$MAX_BODY" ]; then
+            echo "::group::Full review before truncation ($SIZE bytes)"
+            cat "$REVIEW_OUTPUT_FILE"
+            echo "::endgroup::"
+            # `|| true` is load-bearing: when the cut lands mid-character, iconv
+            # writes the valid prefix but still exits non-zero ("incomplete
+            # character"), and under this step's pipefail that would fail the
+            # run on exactly the input truncation exists to handle.
+            head -c "$MAX_BODY" "$REVIEW_OUTPUT_FILE" | iconv -f UTF-8 -t UTF-8 -c > /tmp/review_truncated.txt || true
+            printf '\n\n> ⚠️ Review truncated from %s to %s bytes to fit GitHub'"'"'s comment size limit. The full text is in this run'"'"'s job log.\n' \
+              "$SIZE" "$MAX_BODY" >> /tmp/review_truncated.txt
+            mv /tmp/review_truncated.txt "$REVIEW_OUTPUT_FILE"
+          fi
+
           # Append the detection metadata here rather than asking the model to
           # emit it. Dedup on the next push then depends on this step, not on LLM
           # instruction-following: one reworded header used to mean the next run
           # could not find its own previous comment, leaving a duplicate forever.
+          # (After truncation, so the markers can never be cut off.)
           {
             printf '\n'
             printf '<!-- reviewed-commit: %s -->\n' "$CURRENT_SHA"
             printf '<!-- deriv-pr-review -->\n'
           } >> "$REVIEW_OUTPUT_FILE"
+
+          # Delete the previous review only NOW, seconds before its replacement
+          # posts. This used to happen in the capture step, an hour earlier —
+          # any engine failure or a cancel-in-progress in between left the PR
+          # with no review at all and destroyed the reviewed-commit SHA. Fresh
+          # fetch (comments may have changed during the engine run), same filter
+          # file the capture step used, delete ALL matches including legacy.
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            | jq -s 'add // []' > /tmp/comments_at_post.json
+          jq -f /tmp/review_marker_filter.jq /tmp/comments_at_post.json \
+            | jq -r '.[].id' \
+            | xargs -r -I {} gh api "repos/${REPO}/issues/comments/{}" -X DELETE
 
           echo "📬 Posting review ($(wc -c < "$REVIEW_OUTPUT_FILE") bytes)..."
           gh pr comment "$PR_NUMBER" --body-file "$REVIEW_OUTPUT_FILE"
@@ -587,7 +743,7 @@ jobs:
           # when "Resolve and validate engine" failed, leaving these env unset.
           EVENT_PAYLOAD=$(jq -n \
             --arg agent "${METRICS_AGENT:-ai_review}" \
-            --arg event_type "$EVENT_TYPE" \
+            --arg event_type "${EVENT_TYPE:-unknown}" \
             --arg timestamp "$TIMESTAMP" \
             --arg pr_number "$PR_NUMBER" \
             --arg repo "$REPO" \

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -261,8 +261,38 @@ jobs:
 
           echo "📋 Review context built ($(wc -c < /tmp/review_context.md) bytes)"
 
-      - name: Remove CLAUDE.md to prevent project config leaking into review
-        run: rm -f CLAUDE.md
+      - name: Strip PR-supplied agent config
+        # Security boundary, not hygiene — and deliberately wider than the
+        # `rm -f CLAUDE.md` this replaces. Everything below is PR-controlled and
+        # reaches the agent as trusted configuration, none of it gated by the
+        # --allowedTools allowlist further down:
+        #   .claude/settings.json  can declare HOOKS, which execute arbitrary
+        #                          commands in this job — the job holds a
+        #                          write-scoped GITHUB_TOKEN and the API key
+        #   .claude/rules/*.md     load on demand when a matching file is read
+        #   .mcp.json              declares MCP servers (arbitrary local commands)
+        #   .claude-plugin/        plugin manifest
+        #   CLAUDE.md, CLAUDE.local.md, AGENTS.md   instruction files
+        #
+        # Recursive, not root-only: Claude Code discovers CLAUDE.md and
+        # CLAUDE.local.md in subdirectories and loads them when it reads files
+        # there, and this review's prompt tells it to traverse into dependencies.
+        # A nested packages/foo/CLAUDE.md therefore reached the model even with the
+        # root file deleted. AGENTS.md is stripped defensively — Claude Code does
+        # not read it natively, but a CLAUDE.md can @import it.
+        #
+        # .git is pruned so the sweep cannot corrupt the checkout.
+        run: |
+          find . -name .git -prune -o -type f \
+            \( -name 'CLAUDE.md' -o -name 'CLAUDE.local.md' -o -name 'AGENTS.md' -o -name '.mcp.json' \) \
+            -print0 | xargs -0 -r rm -f
+          find . -name .git -prune -o -type d \
+            \( -name '.claude' -o -name '.claude-plugin' \) \
+            -print0 | xargs -0 -r rm -rf
+          # Persistent runner: clear cross-run agent state too.
+          rm -rf "$HOME/.claude"
+          rm -f "$HOME/.claude.json"
+          echo "✅ Stripped PR-supplied agent config (recursive)"
 
       - name: Claude Code PR Review
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa


### PR DESCRIPTION
Full-flow review of `ai-pr-review.yml` + both engines. Two commits: the first is PR #115 cherry-picked unchanged (it closes the `.claude/settings.json` hooks vector in the deprecated-but-live-in-14-repos `claude-pr-review.yml` — this PR supersedes #115, which can be closed if this merges). The second is the hardening pass below.

## Review-integrity fixes — the previous review could be destroyed

**Deletion moves from the capture step to the post step.** The old flow deleted every prior review comment at the *start* of the run, up to an hour before the replacement posted. Any engine 400 (the exact failures this repo spent last week debugging), timeout, or `cancel-in-progress` from a new push in that window left the PR with **no review comment**, destroyed the `reviewed-commit` SHA, and silently degraded the next run to an initial review. Deletion now happens seconds before posting, using the same filter file the capture step wrote — a failed run leaves the old review untouched. Everything in the post step before the delete is fail-closed on purpose.

**Comment-size guard.** GitHub caps issue comments at 65,536 chars; an over-long model output got a 422 *after* the old comment was gone. Now: full text to the job log, truncate to 64,000 bytes (UTF-8-safe via `iconv -c`, with `|| true` because iconv exits non-zero on a mid-character cut even when it writes the valid prefix), markers appended after truncation so they can never be cut off.

**Exfiltration guard.** Actions masks secrets in *logs*, not in comment bodies — and the review text is derived from attacker-influenced input (diff, PR description). The post step now refuses to publish a review containing the `LLM_API_KEY` value. This also mitigates the Kimi engine's unscoped `Read` (`/proc/*/environ` holds the key; scoping Read needs a verification run and is documented as open).

## Security fixes

- **Checkout by `head.sha`, not `head.ref`** — on `pull_request_target` the branch can move past the commit whose actor the access gate validated; the SHA is what the event attests. Also makes the `reviewed-commit` marker mean what it says.
- **Prompt gist pinned to a revision** (`2d5131aa…`, verified byte-identical to current). The bare `raw/` URL was the one mutable unpinned dependency in an otherwise SHA-pinned flow: a gist edit rewrote the review agent's instructions for every consumer, live, with no PR and no audit trail. Rolling out a new prompt is now a one-line revision bump via PR.
- **Acknowledged-suggestions channel authenticated.** `Click2Fix - Acknowledge` comments were matched from *any* account — a ready-made finding-suppression channel (\"- any concern about the auth change\"). Now restricted to `github-actions[bot]` or authors whose `author_association` is OWNER/MEMBER/COLLABORATOR (server-computed, unspoofable). The scan was also unpaginated (silently ignored acknowledge comments past the first 30) and swallowed API errors; it now reuses the capture step's paginated fetch.

## Cleanups

- **Bot PRs skip instead of failing red** — `*[bot]` actors can't pass the org-membership gate, so every dependabot PR produced a failed run that read like a regression. Humans failing the gate still fail red (correct signal).
- **Every engine-neutral default lives in exactly one place** (the resolve step). Input declarations default to `\"\"`; the `|| 'fallback'` duplicates at each use site — where defaults drift — are gone.
- **Noise filter applies to the main diff too**, not just the incremental one (lockfile churn was eating the 1M-token window on exactly the PRs most likely to blow it). Falls back to the unfiltered diff when everything matches, so a lockfile-only PR still gets reviewed. Pattern moved to job env — one definition.
- **The 5-step review procedure moved into the caller-built context file.** Both engine prompts carried drifting copies; they're now three-line bootstraps pointing at the context.
- **Anthropic engine sandbox: docs corrected against source, plus a belt.** Verified in the action's source at the pinned SHA: with `prompt:` (agent mode) and `--allowedTools \"Read,Write\"`, **no GitHub MCP server is mounted at all** — the docs' \"base GitHub tools are always included\" describes tag mode. The engine's comments and the README previously understated this. Added `--disallowedTools` for those servers plus Bash/WebFetch/WebSearch so a future SHA bump that changes agent-mode defaults fails safe.
- Metrics `event_type` falls back to `unknown` when the run died before context build.

## Verification

- [x] `actionlint 1.7.12 -shellcheck=` clean across all workflows
- [x] lint-actions gate greps (empty expression pair / `timeout-minutes` / `secrets.`) clean on all composite actions
- [x] YAML parse + `bash -n` on all 24 `run:` blocks in the four changed files
- [x] jq marker filter, acknowledged author filter, SHA extraction, and empty-comment-list guard exercised against fixture data (attacker's acknowledge comment excluded; member's and bot's pass; legacy + canonical markers both matched)
- [x] Truncation pipeline exercised, including the mid-multibyte-cut case (caught a real bug: iconv's non-zero exit under pipefail — hence the `|| true`)
- [x] Pinned gist revision fetched, byte-identical to the live unpinned URL
- [x] PR #115's strip step verified per its own fixture plan when originally reviewed
- [ ] One real review run after merge (engines resolve @master, so the dogfooding caller exercises this only post-merge)

## Behaviour changes consumers will notice

- Bot-authored PRs no longer get failed review runs (skipped instead).
- Reviews of huge PRs no longer include lockfile/generated churn in the model's context.
- A PR with only noise-pattern changes still gets a review (of the unfiltered diff) rather than a hard error.
- Drive-by \"acknowledge\" comments from accounts without repo standing are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)