### PR TITLE
feat: add generate_app_info action to stamp build with production tag

### DIFF
--- a/.github/actions/generate_app_info/README.md
+++ b/.github/actions/generate_app_info/README.md
@@ -31,36 +31,59 @@ Given a tag, it writes this file into the directory you point it at:
 
 ## Usage
 
-Add a step **after your build step** (so the file lands in the final build
-output and gets deployed with it):
+Add a step **after your build step and before your Cloudflare Pages publish
+step**, so the file lands in the final build output and gets deployed with it.
+No checkout of `shared-actions` is needed — referencing the action with `uses:`
+is enough.
+
+Example from a production workflow triggered by pushing a `production_*` tag
+(derivatives-trader style, where the deployed output is `packages/core/dist`):
 
 ```yaml
+on:
+  push:
+    tags:
+      - production_*
+
+# ...
+
 steps:
   - name: Checkout
     uses: actions/checkout@v4
 
   - name: Build
-    run: npm run build
+    uses: "./.github/actions/build"
+    with:
+      NODE_ENV: production
+      # ...
 
   - name: Generate app-info.json
     uses: "deriv-com/shared-actions/.github/actions/generate_app_info@master"
     with:
-      version: ${{ github.event.inputs.tag }}
-      output_dir: dist
+      version: ${{ github.ref_name }} # the production_* tag that triggered the workflow
+      output_dir: packages/core/dist
 
-  # ... your deploy step (Cloudflare Pages, Vercel, etc.)
+  - name: Publish to Cloudflare Pages Production
+    uses: "./.github/actions/publish_to_pages_production"
+    with:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
+
+`output_dir` must be the same directory your publish step deploys (the
+argument to `wrangler pages deploy`), so `app-info.json` ends up at the site
+root.
 
 ### Where does the tag come from?
 
 Pass whatever identifies the release in your pipeline. Common sources:
 
 ```yaml
+# Workflow triggered by pushing a tag (e.g. production_*)
+version: ${{ github.ref_name }}
+
 # Production workflow triggered manually with a tag input
 version: ${{ github.event.inputs.tag }}
-
-# Workflow triggered by pushing a tag
-version: ${{ github.ref_name }}
 
 # Release event
 version: ${{ github.event.release.tag_name }}

--- a/.github/actions/generate_app_info/README.md
+++ b/.github/actions/generate_app_info/README.md
@@ -1,0 +1,82 @@
+# generate_app_info
+
+Composite action that creates or updates an `app-info.json` file in your build
+output directory, stamping it with the production tag of the release. Frontends
+(or monitoring) can then fetch `/app-info.json` to know exactly which version
+is deployed.
+
+## What it does
+
+Given a tag, it writes this file into the directory you point it at:
+
+```json
+{
+  "version": "<the tag you passed>"
+}
+```
+
+- If the file does not exist, it is created.
+- If it already exists, it is overwritten with the new version.
+- The JSON is generated with `jq`, so any special characters in the tag are
+  safely escaped.
+- The action fails early with a clear error if the target directory does not
+  exist (e.g., if you run it before your build step).
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `version` | ✅ yes | — | The production tag to write as the version (e.g., `production_V20260813_0`) |
+| `output_dir` | no | `.` | Directory in which your compiled frontend is located (where `app-info.json` will be written) |
+
+## Usage
+
+Add a step **after your build step** (so the file lands in the final build
+output and gets deployed with it):
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+
+  - name: Build
+    run: npm run build
+
+  - name: Generate app-info.json
+    uses: "deriv-com/shared-actions/.github/actions/generate_app_info@master"
+    with:
+      version: ${{ github.event.inputs.tag }}
+      output_dir: dist
+
+  # ... your deploy step (Cloudflare Pages, Vercel, etc.)
+```
+
+### Where does the tag come from?
+
+Pass whatever identifies the release in your pipeline. Common sources:
+
+```yaml
+# Production workflow triggered manually with a tag input
+version: ${{ github.event.inputs.tag }}
+
+# Workflow triggered by pushing a tag
+version: ${{ github.ref_name }}
+
+# Release event
+version: ${{ github.event.release.tag_name }}
+```
+
+### Verifying the deployment
+
+After deploy, the file is served from the site root:
+
+```bash
+curl https://your-app.example.com/app-info.json
+# {"version": "production_V20260813_0"}
+```
+
+## Notes
+
+- `output_dir` must already exist — run this action after the build, not before.
+- Everything in this repo is consumed at `@master`, so changes to this action
+  are live for all consumers as soon as they merge.

--- a/.github/actions/generate_app_info/action.yml
+++ b/.github/actions/generate_app_info/action.yml
@@ -1,0 +1,26 @@
+name: generate_app_info
+description: Create or update app-info.json with the production tag in the build output directory
+inputs:
+  version:
+    description: "Production tag to write as the version (e.g., production_V20260813_0)"
+    required: true
+  output_dir:
+    description: "Directory in which your compiled frontend is located"
+    required: false
+    default: "."
+runs:
+  using: composite
+  steps:
+    - name: Create or update app-info.json
+      env:
+        VERSION: ${{ inputs.version }}
+        OUTPUT_DIR: ${{ inputs.output_dir }}
+      run: |
+        if [ ! -d "$OUTPUT_DIR" ]; then
+          echo "::error::Output directory '$OUTPUT_DIR' does not exist"
+          exit 1
+        fi
+        jq -n --arg version "$VERSION" '{version: $version}' > "$OUTPUT_DIR/app-info.json"
+        echo "Wrote $OUTPUT_DIR/app-info.json:"
+        cat "$OUTPUT_DIR/app-info.json"
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.env
 .env.*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Add a row here when deprecating anything. With no CHANGELOG and no release proce
           head_sha: ${{github.event.workflow_run.head_sha}}
 ```
 
+### App info (version stamp)
+
+[`generate_app_info`](.github/actions/generate_app_info/) creates or updates an
+`app-info.json` file in the build output directory containing the production tag.
+Full docs: [generate_app_info README](.github/actions/generate_app_info/README.md).
+
+```yaml
+      - name: Generate app-info.json
+        uses: "deriv-com/shared-actions/.github/actions/generate_app_info@master"
+        with:
+          version: ${{ github.event.inputs.tag }} # the production tag
+          output_dir: dist # optional, defaults to "."
+```
+
+Output file:
+
+```json
+{ "version": "<the tag passed>" }
+```
+
 ### Archive on Merge (openspec)
 
 When a PR that completes an openspec change merges, archive it and open a


### PR DESCRIPTION
## Summary

Adds a new composite action `generate_app_info` that consumer repos can add as a step in their production pipeline. It creates or updates an `app-info.json` file in the build output directory, stamped with the production tag:

```json
{ "version": "<the tag passed>" }
```

## Details

- **Inputs:** `version` (required — the production tag) and `output_dir` (optional, defaults to `.`)
- JSON is generated with `jq` so special characters in the tag are safely escaped (no shell/JSON injection)
- Fails early with a clear error annotation if `output_dir` doesn't exist (i.e., action ran before the build step)
- Includes a per-action README with usage examples and a section in the main README
- Also adds `.DS_Store` to `.gitignore`

## Usage

```yaml
- name: Generate app-info.json
  uses: "deriv-com/shared-actions/.github/actions/generate_app_info@master"
  with:
    version: ${{ github.event.inputs.tag }}
    output_dir: dist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)