### PR TITLE
fix: stop losing reviews when the agent skips the output file

### DIFF
--- a/.github/actions/ai_review_engine_anthropic/action.yml
+++ b/.github/actions/ai_review_engine_anthropic/action.yml
@@ -169,13 +169,16 @@ runs:
           the full review instructions, PR context, previous review (if any),
           acknowledged suggestions to skip, and the required output format — plus a
           "Review Procedure" section telling you what else to read, including the
-          pre-fetched PR diff at ${{ inputs.pr_diff_path }}, and requiring you to
-          write your complete review to ${{ inputs.output_path }} with the Write
-          tool. You have no shell tool; everything you need is on disk.
+          pre-fetched PR diff at ${{ inputs.pr_diff_path }}. You have no shell tool;
+          everything you need is on disk.
 
-          Do NOT post, create or update any PR or issue comment, and do not use
-          any GitHub tool to publish your review. Writing the file is the whole
-          job — the caller posts it as a single comment.
+          HOW THIS TASK IS DELIVERED: your chat reply is discarded and never reaches
+          anyone. The ONLY output that counts is the file ${{ inputs.output_path }},
+          written with the Write tool. So your final action must be that Write call,
+          containing the complete review. Do NOT post, create or update any PR or
+          issue comment and do not use any GitHub tool to publish the review — and
+          do not treat any comment you can see on the PR as the delivery. If the
+          file is missing the job fails with no review at all.
         # Bash is dropped entirely: the diff is pre-fetched, so the previous
         # `Bash(gh pr diff:*)` grant bought nothing and rested on the CLI's
         # command-pattern matching being argv-aware — under a naive prefix match,

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -291,6 +291,12 @@ runs:
         # configure step — would be posted as a review of the wrong PR.
         rm -f "$OUTPUT_PATH"
 
+        # Read once, outside the loop: both attempts then provably run the same
+        # prompt. Re-reading per attempt would also mean an empty prompt reaching
+        # the CLI — and a garbage review — if the file ever went missing between
+        # attempts, rather than failing.
+        REVIEW_PROMPT="$(cat /tmp/review_prompt.txt)"
+
         # No GitHub token in this step's env and no Bash tool in the config: the
         # agent cannot reach the GitHub API at all. The caller's post step is the
         # only thing that can comment on the PR.
@@ -303,7 +309,7 @@ runs:
         # written keeps the cost bounded (worst case two passes inside the
         # caller's 60-minute timeout) and never re-runs a review that worked.
         for attempt in 1 2; do
-          kimi -p "$(cat /tmp/review_prompt.txt)" && KIMI_STATUS=0 || KIMI_STATUS=$?
+          kimi -p "$REVIEW_PROMPT" && KIMI_STATUS=0 || KIMI_STATUS=$?
 
           # A written review is the deliverable, so it outranks the exit code:
           # the CLI can fail on a trailing empty turn AFTER the model has written

--- a/.github/actions/ai_review_engine_kimi/action.yml
+++ b/.github/actions/ai_review_engine_kimi/action.yml
@@ -208,9 +208,14 @@ runs:
         the full review instructions, PR context, previous review (if any),
         acknowledged suggestions to skip, and the required output format — plus a
         "Review Procedure" section telling you what else to read, including the
-        pre-fetched PR diff at ${{ inputs.pr_diff_path }}, and requiring you to
-        write your complete review to ${{ inputs.output_path }} with the Write
-        tool. You have no shell tool; everything you need is on disk.
+        pre-fetched PR diff at ${{ inputs.pr_diff_path }}. You have no shell tool;
+        everything you need is on disk.
+
+        HOW THIS TASK IS DELIVERED: your chat reply is discarded and never reaches
+        anyone. The ONLY output that counts is the file ${{ inputs.output_path }},
+        written with the Write tool. So your final action must be that Write call,
+        containing the complete review. Writing an analysis as your reply instead
+        means the review is lost and the job fails.
         EOF
 
         # Dumps the CLI's own log on failure. Without this the step reports only
@@ -224,11 +229,15 @@ runs:
         # AI_PR_REVIEW_README.md. What stays is what a failing run cannot be
         # debugged without: the resolved config, the input sizes, and the CLI's own
         # log if it wrote one.
+        # ALWAYS call this as `( dump_kimi_log ) || true`. The subshell is what
+        # keeps the `set +e` below from leaking: some call sites now continue
+        # running afterwards (the retry, and the salvage path), and silently
+        # disabling -e for the rest of the step would be a nasty surprise. The
+        # `|| true` covers the function itself ending non-zero.
         dump_kimi_log() {
           # A diagnostic must never be killed by the thing it is diagnosing. The
           # step runs under `bash -e -o pipefail`, so any non-zero command in here
-          # would abort the dump partway and hide the rest. Both call sites `exit`
-          # explicitly straight after, so relaxing this has no other effect.
+          # would abort the dump partway and hide the rest.
           set +e +o pipefail
 
           # tr strips the padding BSD wc emits, harmless on the Linux runner.
@@ -236,6 +245,15 @@ runs:
 
           echo "ℹ️  config: model=$KIMI_MODEL_NAME base_url=$KIMI_MODEL_BASE_URL provider_type=$KIMI_MODEL_PROVIDER_TYPE max_context_size=$KIMI_MODEL_MAX_CONTEXT_SIZE"
           echo "ℹ️  input bytes: context=$(bytes_of "$CONTEXT_PATH") diff=$(bytes_of "$DIFF_PATH") prompt=$(bytes_of /tmp/review_prompt.txt)"
+          # Whether the review survived is the first thing anyone reading this
+          # needs, and it used to be absent: a CLI that dies after writing looks
+          # identical in the log to one that never wrote anything, and the two
+          # have completely different causes.
+          if [[ -s "$OUTPUT_PATH" ]]; then
+            echo "ℹ️  review file: PRESENT at $OUTPUT_PATH ($(bytes_of "$OUTPUT_PATH") bytes) — the review itself survived"
+          else
+            echo "ℹ️  review file: ABSENT at $OUTPUT_PATH — the model never called Write"
+          fi
 
           # The CLI names $HOME/.kimi-code/logs/kimi-code.log in its errors but does
           # not always create it, so search rather than assume.
@@ -261,25 +279,58 @@ runs:
           echo "    agent had started reading files, config is probably fine —"
           echo "    suspect the endpoint rejecting a mid-conversation request, and"
           echo "    check whether the model alias fronts more than one deployment."
+          echo "    'The API returned an empty response' means the model ended its"
+          echo "    turn with no content and no tool call: it stopped without"
+          echo "    writing the review, or the provider returned only reasoning"
+          echo "    content. That one is transient — the retry below covers it."
         }
+
+        # Clean slate first. The checks below treat a non-empty file at this path
+        # as THIS run's deliverable, so a leftover from an earlier job — possible
+        # on a persistent runner, same reason $HOME/.kimi-code is recreated in the
+        # configure step — would be posted as a review of the wrong PR.
+        rm -f "$OUTPUT_PATH"
 
         # No GitHub token in this step's env and no Bash tool in the config: the
         # agent cannot reach the GitHub API at all. The caller's post step is the
         # only thing that can comment on the PR.
-        kimi -p "$(cat /tmp/review_prompt.txt)" && KIMI_STATUS=0 || KIMI_STATUS=$?
+        #
+        # Run it up to twice. The failure this covers is the CLI aborting with
+        # "The API returned an empty response (no content, no tool calls)" —
+        # kimi-k3 ending a turn with neither, which the CLI treats as fatal after
+        # the agent has already spent minutes reading the code. It is transient:
+        # the same PR succeeds on a re-run. Retrying only when NO review was
+        # written keeps the cost bounded (worst case two passes inside the
+        # caller's 60-minute timeout) and never re-runs a review that worked.
+        for attempt in 1 2; do
+          kimi -p "$(cat /tmp/review_prompt.txt)" && KIMI_STATUS=0 || KIMI_STATUS=$?
 
-        if [[ "$KIMI_STATUS" -ne 0 ]]; then
-          echo "❌ Kimi engine: CLI exited $KIMI_STATUS"
-          dump_kimi_log
-          exit "$KIMI_STATUS"
-        fi
+          # A written review is the deliverable, so it outranks the exit code:
+          # the CLI can fail on a trailing empty turn AFTER the model has written
+          # the file, and failing the job then would discard a complete review.
+          # The file is produced by a single Write call, so a non-empty file is a
+          # whole review rather than a partial one.
+          if [[ -s "$OUTPUT_PATH" ]]; then
+            if [[ "$KIMI_STATUS" -ne 0 ]]; then
+              echo "⚠️  Kimi engine: CLI exited $KIMI_STATUS AFTER writing the review — keeping the review and continuing."
+              ( dump_kimi_log ) || true
+            fi
+            break
+          fi
+
+          if [[ "$attempt" -eq 1 ]]; then
+            echo "⚠️  Kimi engine: CLI exited $KIMI_STATUS with no review written — retrying once."
+            ( dump_kimi_log ) || true
+            echo "🔁 Kimi engine: attempt 2 of 2"
+          fi
+        done
 
         # Fail here, named, rather than letting the caller report a generic
         # "review file missing" — all steps in a composite action share one log
         # group, so an engine-attributed error is what makes this locatable.
         if [[ ! -s "$OUTPUT_PATH" ]]; then
-          echo "❌ Kimi engine: the CLI finished but wrote no review to $OUTPUT_PATH"
-          dump_kimi_log
+          echo "❌ Kimi engine: no review written to $OUTPUT_PATH after 2 attempts (last CLI exit: $KIMI_STATUS)"
+          ( dump_kimi_log ) || true
           exit 1
         fi
         echo "✅ Kimi engine: review written ($(wc -c < "$OUTPUT_PATH") bytes)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -328,8 +328,14 @@ jobs:
                - Related test files (e.g. *.spec.ts, *.test.ts) to assess coverage gaps
 
             5. After reading ALL files and dependencies, compile your complete review.
-               Write the ENTIRE review to /tmp/claude_review_output.txt using the Write tool.
-               Do NOT call gh pr comment — the next step posts the file as a single comment.
+
+               HOW THIS TASK IS DELIVERED: your chat reply is discarded and never
+               reaches anyone. The ONLY output that counts is the file
+               /tmp/claude_review_output.txt, written with the Write tool. So your
+               final action must be that Write call, containing the complete review.
+               Do NOT call gh pr comment, and do not treat any comment you can see
+               on the PR as the delivery — the next step posts the file, and if the
+               file is missing the job fails with no review at all.
           # Write is unrestricted (plain "Write", not "Write(/path)") so the tool is actually available.
           # Bash(gh pr comment) is intentionally excluded — the post step below guarantees exactly one comment.
           # model moved to claude_args — `model` is no longer a valid action input.


### PR DESCRIPTION
Reviews are being silently lost by both reviewers because the agent finishes without writing the output file. This fixes the shared cause (prompt wording) for all three review paths, and adds salvage + retry to the Kimi engine where the failure is recoverable.

## The evidence

**Claude (`claude-pr-review.yml`)** — failing on the same step, three times in the last fourteen runs:

| Date | Branch | Failing step |
|---|---|---|
| 08-14 11:58 | `fix/kimi-engine-salvage-review` | Post review as single PR comment |
| 08-13 10:39 | `docs/kimi-400-root-cause` | Post review as single PR comment |
| 08-13 07:19 | `docs/kimi-400-root-cause` | Post review as single PR comment |

It **succeeded** on that same branch at 10:22 — 17 minutes before the 10:39 failure, on near-identical content. So it's intermittent, roughly **1 in 5**, and has been happening for at least two days. On the 08-14 run Sonnet's final message was *"Review posted."* while no file existed; the only thing on the PR was claude-code-action's own tracking comment.

**Kimi** — [one run](https://github.com/deriv-com/deriv-api-v2/actions/runs/31794240907) spent 8.5 minutes reviewing, then died with `The API returned an empty response (no content, no tool calls)` and no file written. Kimi only reached this failure today: every earlier run died at the proxy (400/403) before the agent got that far, so fixing the token revealed the layer underneath.

## Root cause

Both prompts only said what *not* to do — *"Do NOT call `gh pr comment`"* — and never that the agent's own reply is worthless. A model that has written a thorough analysis in chat, or that can see a tracking comment on the PR, can reasonably conclude it's done.

## Changes

**All three paths** (`claude-pr-review.yml`, the Anthropic engine, the Kimi engine) now state it positively: the chat reply is discarded and reaches no one, the file is the only output that counts, the final action must be that `Write` call, and a missing file means no review at all. Plus explicitly: a comment already visible on the PR is **not** the delivery — the specific thing that misled Sonnet.

**Kimi engine only**, where the failure is recoverable:

1. **A written review now outranks the CLI's exit code** — the CLI can abort on a trailing empty turn *after* the model wrote the file, and we were discarding a complete review. The file comes from a single `Write` call, so a non-empty file is never partial.
2. **One retry when the CLI fails having written nothing.** Bounded: never re-runs a review that worked, worst case two passes inside the caller's 60-minute timeout. This alone would have turned the linked run green.
3. **The failure dump reports whether the review file exists** — a CLI that died *after* writing looked identical in the log to one that never wrote. This was the missing datum when diagnosing that run.

Two hazards the salvage path itself introduced, both closed: the output file is **removed before the first attempt** (a leftover from an earlier job would otherwise be posted as a review of the wrong PR), and every `dump_kimi_log` call is wrapped `( dump_kimi_log ) || true` (the function disables `-e` for its own protection, which was harmless only while every caller exited immediately after).

## Verification

The Kimi loop was extracted from the action and run under `bash -e -o pipefail` against a stub CLI:

| Scenario | Outcome |
|---|---|
| CLI succeeds and writes | ✅ review kept, exit 0 |
| CLI fails **after** writing | ⚠️ warned, **review kept**, exit 0 |
| CLI fails, no file, retry succeeds | 🔁 retried, review kept, exit 0 |
| CLI fails twice, never writes | ❌ exit 1, engine-named message |
| Stale file present, CLI fails | ❌ exit 1, **stale review not posted** |
| Stale file present, CLI succeeds | ✅ fresh review replaces the stale one |

A canary after the loop confirms `-e` is still active following a dump. Plus `actionlint 1.7.12 -shellcheck=` clean, composite-action lint gate clean, all three manifests parse, every `run:` block passes `bash -n`, and the delivery wording is asserted present in all three prompts.

The two prompt-only changes carry no logic, so there is nothing to exercise beyond the manifests — and prompt-following can only really be judged on real runs after merge.

## Known limits

- If reviews routinely exceed ~25 minutes, a Kimi retry could approach the caller's 60-minute `timeout-minutes`. Today's runs are 8–15 minutes.
- **Salvage stays Kimi-only.** The Anthropic path runs inside a `uses:` step, so keeping a review written before a late failure needs `continue-on-error` plus a real Claude run to verify — not something this branch can exercise.
- The prompt change reduces the odds; it cannot make an agent obey. If failures continue, the next lever is a hard check in the Anthropic path equivalent to the Kimi retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)